### PR TITLE
Issue #6: simplify using separate databases for custom ontologies.

### DIFF
--- a/docs/source/snomed_and_loinc.rst
+++ b/docs/source/snomed_and_loinc.rst
@@ -33,14 +33,14 @@ Once the content is downloaded, users can import it with the following commands.
 :py:func:`~bunsen.mapping.loinc.with_loinc_hierarchy` and :py:func:`~bunsen.snomed.loinc.with_relationships`
 functions for details.
 
->>> from bunsen.mapping import get_empty_hierarchies
+>>> from bunsen.mapping import create_hierarchies
 >>> from bunsen.mapping.loinc import with_loinc_hierarchy
 >>> from bunsen.mapping.snomed import with_relationships
 >>>
 >>> # Add SNOMED to the value sets
 >>> snomed_hierarchy= with_relationships(
 >>>       spark,
->>>       get_empty_hierarchies(spark),
+>>>       create_hierarchies(spark),
 >>>       '/path/to/mappings/snomedct_rf2/20160901/Snapshot/Terminology/sct2_Relationship_Snapshot_US1000124_20160901.txt',
 >>>       '20160901')
 >>>
@@ -57,7 +57,7 @@ functions for details.
 
 
 FHIR ValueSet and ConceptMap APIs, and APIs for hierarchical systems
---------------------
+--------------------------------------------------------------------
 
 .. automodule:: bunsen.mapping
     :members:

--- a/python/bunsen/mapping/__init__.py
+++ b/python/bunsen/mapping/__init__.py
@@ -10,41 +10,59 @@ from pyspark.sql import functions, DataFrame
 import collections
 import datetime
 
-def get_default_concept_maps(spark_session):
+def get_concept_maps(spark_session, database='ontologies'):
+    """
+    Returns a :class:`ConceptMaps` instance for the given database.
+    """
     jconcept_maps = spark_session._jvm.com.cerner.bunsen.mappings \
-      .ConceptMaps.getDefault(spark_session._jsparkSession)
+      .ConceptMaps.getFromDatabase(spark_session._jsparkSession, database)
 
     return ConceptMaps(spark_session, jconcept_maps)
 
-def get_empty_concept_maps(spark_session):
+def create_concept_maps(spark_session):
+    """
+    Creates a new, empty :py:class:`ConceptMaps` instance.
+    """
     jconcept_maps = spark_session._jvm.com.cerner.bunsen.mappings \
       .ConceptMaps.getEmpty(spark_session._jsparkSession)
 
     return ConceptMaps(spark_session, jconcept_maps)
 
-def get_default_value_sets(spark_session):
+def get_value_sets(spark_session, database='ontologies'):
+    """
+    Returns a :class:`ValueSets` instance for the given database.
+    """
     jvalue_sets = spark_session._jvm.com.cerner.bunsen.mappings \
-      .ValueSets.getDefault(spark_session._jsparkSession)
+      .ValueSets.getFromDatabase(spark_session._jsparkSession, database)
 
     return ValueSets(spark_session, jvalue_sets)
 
-def get_empty_value_sets(spark_session):
+def create_value_sets(spark_session):
+    """
+    Creates a new, empty :class:`ValueSets` instance.
+    """
     jvalue_sets = spark_session._jvm.com.cerner.bunsen.mappings \
       .ValueSets.getEmpty(spark_session._jsparkSession)
 
     return ValueSets(spark_session, jvalue_sets)
 
-def get_default_hierarchies(spark_session):
-  jhierarchies = spark_session._jvm.com.cerner.bunsen.mappings \
-      .Hierarchies.getDefault(spark_session._jsparkSession)
+def get_hierarchies(spark_session, database='ontologies'):
+    """
+    Returns a :class:`Hierarchies` instance for the given database.
+    """
+    jhierarchies = spark_session._jvm.com.cerner.bunsen.mappings \
+        .Hierarchies.getFromDatabase(spark_session._jsparkSession, database)
 
-  return Hierarchies(spark_session, jhierarchies)
+    return Hierarchies(spark_session, jhierarchies)
 
-def get_empty_hierarchies(spark_session):
-  jhierarchies = spark_session._jvm.com.cerner.bunsen.mappings \
-      .Hierarchies.getEmpty(spark_session._jsparkSession)
+def create_hierarchies(spark_session):
+    """
+    Creates a new, empty :class:`Hierarchies` instance.
+    """
+    jhierarchies = spark_session._jvm.com.cerner.bunsen.mappings \
+        .Hierarchies.getEmpty(spark_session._jsparkSession)
 
-  return Hierarchies(spark_session, jhierarchies)
+    return Hierarchies(spark_session, jhierarchies)
 
 def _add_mappings_to_map(jvm, concept_map, mappings):
     """

--- a/python/bunsen/valuesets.py
+++ b/python/bunsen/valuesets.py
@@ -5,7 +5,7 @@ in Spark queries.
 
 from collections import namedtuple
 
-from bunsen.mapping import get_default_value_sets, get_default_hierarchies
+from bunsen.mapping import get_value_sets, get_hierarchies
 
 # Placeholder record to load a particular value set
 ValueSetPlaceholder = namedtuple("ValueSetPlaceholder",
@@ -35,7 +35,7 @@ def isa_snomed(code_value, snomed_version=None):
                                 'urn:com:cerner:bunsen:hierarchy:snomed',
                                 snomed_version)
 
-def push_valuesets(spark_session, valueset_map, value_sets=None, hierarchies=None):
+def push_valuesets(spark_session, valueset_map, database='ontologies'):
     """
     Pushes valuesets onto a stack and registers an in_valueset user-defined function
     that uses this content.
@@ -48,12 +48,15 @@ def push_valuesets(spark_session, valueset_map, value_sets=None, hierarchies=Non
     or HierarchyPlaceholder that instructs the system to load codes belonging to a particular
     value set or hierarchical system, respectively. See the isa_loinc and isa_snomed functions
     above for details.
-    """
-    if value_sets is None:
-        value_sets = get_default_value_sets(spark_session)
 
-    if hierarchies is None:
-        hierarchies = get_default_hierarchies(spark_session)
+    Finally, ontology information is assumed to be stored in the 'ontologies' database by
+    default, but users can specify another database name if they have customized
+    ontologies that are separated from the default ontologies database.
+    """
+
+    value_sets = get_value_sets(spark_session, database)
+
+    hierarchies = get_hierarchies(spark_session, database)
 
     jvm = spark_session._jvm
 


### PR DESCRIPTION
Simplify using separate databases for ontologies for issue #6.