### PR TITLE
issue-38: adding new_version parameter and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ docs/build
 
 # Test Artifacts #
 *.crc
+
+# VirtualEnv #
+venv

--- a/python/bunsen/codes/__init__.py
+++ b/python/bunsen/codes/__init__.py
@@ -392,7 +392,7 @@ class ValueSets(object):
                        self._jfunctions,
                        self._java_package)
 
-    def add_values(self, url, version, values):
+    def add_values(self, url, version, new_version, values):
         """
         Returns a new ValueSets instance with the given values added to an
         existing value set. The values parameter must be a list of the form
@@ -400,10 +400,13 @@ class ValueSets(object):
 
         :param url: URL of the ValueSet to add values to
         :param version: Version of the ValueSet to add values to
+        :param new_version: Version of the updated ValueSet to which new values
+            have been added
         :param mappings: A list of tuples representing the values to add
         :return: a :class:`ValueSets` instance with the added values
         """
         value_set = self._jvalue_sets.getValueSet(url, version)
+        value_set.setVersion(new_version)
 
         _add_values_to_value_set(self._jvm, value_set, values)
 

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -41,7 +41,7 @@
               </arguments>
               <skip>${skip.python.tests}</skip>
               <environmentVariables>
-                <PYTHONPATH>${project.basedir}</PYTHONPATH>
+                <PYTHONPATH>${env.PYTHONPATH}:${project.basedir}</PYTHONPATH>
                 <SHADED_JAR_PATH>${project.parent.basedir}/bunsen-shaded/target/bunsen-shaded-${project.version}.jar</SHADED_JAR_PATH>
               </environmentVariables>
             </configuration>

--- a/python/tests/test_bunsen_r4.py
+++ b/python/tests/test_bunsen_r4.py
@@ -211,6 +211,32 @@ def test_add_valueset(spark_session):
   assert appended.get_value_sets().count() == 1
   assert appended.get_values().count() == 3
 
+def test_add_values(spark_session):
+
+  value_sets = create_value_sets(spark_session)
+
+  original = [('http://snomed.info/sct', '75367002')]
+
+  added = [('http://snomed.info/sct', '271649006')]
+
+  appended = value_sets.with_new_value_set(url='urn:cerner:test:valuesets:testvalueset',
+                                           version='0.1',
+                                           values=original) \
+                       .add_values(url='urn:cerner:test:valuesets:testvalueset',
+                                   version='0.1',
+                                   new_version='0.2',
+                                   values=added)
+
+  assert appended.get_values().count() == 3
+  assert appended.get_values() \
+      .where(col('valueseturi') == 'urn:cerner:test:valuesets:testvalueset') \
+      .where(col('valuesetversion') == '0.1') \
+      .count() == 1
+  assert appended.get_values() \
+      .where(col('valueseturi') == 'urn:cerner:test:valuesets:testvalueset') \
+      .where(col('valuesetversion') == '0.2') \
+      .count() == 2
+
 def test_latest_valueset_version(spark_session):
 
   value_sets = create_value_sets(spark_session)

--- a/python/tests/test_bunsen_stu3.py
+++ b/python/tests/test_bunsen_stu3.py
@@ -211,6 +211,32 @@ def test_add_valueset(spark_session):
   assert appended.get_value_sets().count() == 1
   assert appended.get_values().count() == 3
 
+def test_add_values(spark_session):
+
+  value_sets = create_value_sets(spark_session)
+
+  original = [('http://snomed.info/sct', '75367002')]
+
+  added = [('http://snomed.info/sct', '271649006')]
+
+  appended = value_sets.with_new_value_set(url='urn:cerner:test:valuesets:testvalueset',
+                                           version='0.1',
+                                           values=original) \
+                       .add_values(url='urn:cerner:test:valuesets:testvalueset',
+                                   version='0.1',
+                                   new_version='0.2',
+                                   values=added)
+
+  assert appended.get_values().count() == 3
+  assert appended.get_values() \
+      .where(col('valueseturi') == 'urn:cerner:test:valuesets:testvalueset') \
+      .where(col('valuesetversion') == '0.1') \
+      .count() == 1
+  assert appended.get_values() \
+      .where(col('valueseturi') == 'urn:cerner:test:valuesets:testvalueset') \
+      .where(col('valuesetversion') == '0.2') \
+      .count() == 2
+
 def test_latest_valueset_version(spark_session):
 
   value_sets = create_value_sets(spark_session)


### PR DESCRIPTION
Fixes #38.

Adds a `new_version` parameter to the [`add_values`](https://engineering.cerner.com/bunsen/0.4.3/stu3_pythonapis.html#bunsen.codes.ValueSets.add_values) method of `ValueSets`. Includes STU3 and R4 tests.