### PR TITLE
issue-40: fixing uri-to-version usage and adding test case

### DIFF
--- a/bunsen-r4/src/main/java/com/cerner/bunsen/r4/codes/ConceptMaps.java
+++ b/bunsen-r4/src/main/java/com/cerner/bunsen/r4/codes/ConceptMaps.java
@@ -315,9 +315,6 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     List<ConceptMap> mapsList = getMaps().collectAsList();
 
-    Map<String,ConceptMap> allMaps = mapsList.stream()
-        .collect(Collectors.toMap(ConceptMap::getUrl, Function.identity()));
-
     Map<String,ConceptMap> mapsToLoad = mapsList
         .stream()
         .filter(conceptMap ->
@@ -326,7 +323,7 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     // Expand the concept maps to load and sort them so dependencies are before
     // their dependents in the list.
-    List<String> sortedMapsToLoad = sortMapsToLoad(conceptMapUriToVersion.keySet(), allMaps);
+    List<String> sortedMapsToLoad = sortMapsToLoad(conceptMapUriToVersion.keySet(), mapsToLoad);
 
     // Since this is used to map from one system to another, we use only targets
     // that don't introduce inaccurate meanings. (For instance, we can't map
@@ -345,7 +342,7 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     for (String conceptMapUri: sortedMapsToLoad) {
 
-      ConceptMap map = allMaps.get(conceptMapUri);
+      ConceptMap map = mapsToLoad.get(conceptMapUri);
 
       Set<String> children = getMapChildren(map);
 

--- a/bunsen-stu3/src/main/java/com/cerner/bunsen/stu3/codes/ConceptMaps.java
+++ b/bunsen-stu3/src/main/java/com/cerner/bunsen/stu3/codes/ConceptMaps.java
@@ -314,9 +314,6 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     List<ConceptMap> mapsList = getMaps().collectAsList();
 
-    Map<String,ConceptMap> allMaps = mapsList.stream()
-        .collect(Collectors.toMap(ConceptMap::getUrl, Function.identity()));
-
     Map<String,ConceptMap> mapsToLoad = mapsList
         .stream()
         .filter(conceptMap ->
@@ -325,7 +322,7 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     // Expand the concept maps to load and sort them so dependencies are before
     // their dependents in the list.
-    List<String> sortedMapsToLoad = sortMapsToLoad(conceptMapUriToVersion.keySet(), allMaps);
+    List<String> sortedMapsToLoad = sortMapsToLoad(conceptMapUriToVersion.keySet(), mapsToLoad);
 
     // Since this is used to map from one system to another, we use only targets
     // that don't introduce inaccurate meanings. (For instance, we can't map
@@ -344,7 +341,7 @@ public class ConceptMaps extends AbstractConceptMaps<ConceptMap, ConceptMaps> {
 
     for (String conceptMapUri: sortedMapsToLoad) {
 
-      ConceptMap map = allMaps.get(conceptMapUri);
+      ConceptMap map = mapsToLoad.get(conceptMapUri);
 
       Set<String> children = getMapChildren(map);
 


### PR DESCRIPTION
Fixes #40, wherein ConceptMaps having URIs with multiple distinct versions would fail to broadcast due to a map-key collision.