### PR TITLE
Upgrade HAPI to 3.6.0

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,5 +5,10 @@ Cerner Corporation
 - Ryan Brush [@rbrush]
 - Aleksander Eskilson [@bdrillard]
 
+CSIRO
+
+- John Grimes [@johngrimes]
+
 [@rbrush]: https://github.com/rbrush
 [@bdrillard]: https://github.com/bdrillard
+[@johngrimes]: https://github.com/johngrimes

--- a/bunsen-r4/src/test/java/com/cerner/bunsen/r4/FhirEncodersTest.java
+++ b/bunsen-r4/src/test/java/com/cerner/bunsen/r4/FhirEncodersTest.java
@@ -110,11 +110,17 @@ public class FhirEncodersTest {
 
   @Test
   public void boundCode() {
+    Row coding = (Row) conditionsDataset.select("verificationStatus")
+                                        .head()
+                                        .getStruct(0)
+                                        .getList(1)
+                                        .get(0);
 
-    Assert.assertEquals(condition.getVerificationStatus().toCode(),
-        conditionsDataset.select("verificationStatus").head().get(0));
-    Assert.assertEquals(condition.getVerificationStatus(),
-        decodedCondition.getVerificationStatus());
+    Assert.assertEquals(condition.getVerificationStatus().getCoding().size(), 1);
+    Assert.assertEquals(condition.getVerificationStatus().getCodingFirstRep().getSystem(),
+                        coding.getString(1));
+    Assert.assertEquals(condition.getVerificationStatus().getCodingFirstRep().getCode(),
+                        coding.getString(3));
   }
 
   @Test

--- a/bunsen-r4/src/test/java/com/cerner/bunsen/r4/SchemaConverterTest.java
+++ b/bunsen-r4/src/test/java/com/cerner/bunsen/r4/SchemaConverterTest.java
@@ -67,9 +67,8 @@ public class SchemaConverterTest {
 
 
   @Test
-  public void boundCodeToString() {
-
-    Assert.assertTrue(getField(conditionSchema, true, "verificationStatus") instanceof StringType);
+  public void boundCodeToStruct() {
+    Assert.assertTrue(getField(conditionSchema, true, "verificationStatus") instanceof StructType);
   }
 
   @Test

--- a/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
+++ b/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
@@ -2,6 +2,7 @@ package com.cerner.bunsen.r4;
 
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Identifier;
@@ -12,6 +13,7 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.codesystems.ConditionVerStatus;
 import org.hl7.fhir.utilities.xhtml.NodeType;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 
@@ -44,7 +46,11 @@ public class TestData {
 
     condition.setSubject(new Reference("Patient/example").setDisplay("Here is a display for you."));
 
-    condition.setVerificationStatus(Condition.ConditionVerificationStatus.CONFIRMED);
+    CodeableConcept verificationStatus = new CodeableConcept();
+    verificationStatus.addCoding(new Coding(ConditionVerStatus.CONFIRMED.getSystem(),
+                                            ConditionVerStatus.CONFIRMED.toCode(),
+                                            ConditionVerStatus.CONFIRMED.getDisplay()));
+    condition.setVerificationStatus(verificationStatus);
 
     // Condition code
     CodeableConcept code = new CodeableConcept();

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <parquet.version>1.7.0</parquet.version>
-    <hapi.fhir.version>3.3.0</hapi.fhir.version>
+    <hapi.fhir.version>3.6.0</hapi.fhir.version>
     <junit.version>4.11</junit.version>
     <scm.url>http://github.com/cerner/bunsen/tree/master/</scm.url>
     <scm.connection>scm:git:git@github.com/cerner/bunsen.git</scm.connection>


### PR DESCRIPTION
### Summary

Upgrade of the HAPI dependencies to version 3.6.0.
