### PR TITLE
issue-48: Uplifting to spark-2.3.2

### DIFF
--- a/bunsen-shaded/pom.xml
+++ b/bunsen-shaded/pom.xml
@@ -48,6 +48,8 @@
                   <include>ca.uhn.hapi.fhir:hapi-fhir-structures-r4</include>
                   <include>ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4</include>
 
+                  <include>org.apache.commons:commons-text</include>
+
                 </includes>
               </artifactSet>
               <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <compile.source>1.8</compile.source>
 
     <!-- Spark -->
-    <spark.version>2.3.0</spark.version>
+    <spark.version>2.3.2</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <parquet.version>1.7.0</parquet.version>


### PR DESCRIPTION
Fixes #48.

Uplifts project to use Spark 2.3.2. It appears the R4 FHIR dependencies require the Apache `commons-text` library to be shaded, otherwise R4 python tests fail with the relevant class not being on the classpath.

Built and ran regressions locally, tested in Notebook environment.