### PR TITLE
Issue 46: Support for Contained Resources

### DIFF
--- a/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
@@ -8,10 +8,14 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import com.cerner.bunsen.datatypes.DataTypeMappings;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import scala.collection.JavaConversions;
 
 /**
  * Spark Encoders for FHIR Resources. This object is thread safe.
@@ -46,7 +50,7 @@ public class FhirEncoders {
   /**
    * Cached encoders to avoid having to re-create them.
    */
-  private final Map<Class, ExpressionEncoder> encoderCache = new HashMap<>();
+  private final Map<Integer, ExpressionEncoder> encoderCache = new HashMap<>();
 
   /**
    * Consumers should generally use the {@link #forStu3()} or {@link #forR4()}
@@ -169,21 +173,41 @@ public class FhirEncoders {
     return new Builder(fhirVersion);
   }
 
+
   /**
    * Returns an encoder for the given FHIR resource.
    *
    * @param type the type of the resource to encode.
+   * @param contained a list of types for FHIR resources contained to the encoded resource.
    * @param <T> the type of the resource to be encoded.
    * @return an encoder for the resource.
    */
-  public <T extends IBaseResource> ExpressionEncoder<T> of(Class<T> type) {
+  public final <T extends IBaseResource> ExpressionEncoder<T> of (Class<T> type,
+      List<Class> contained) {
+
 
     BaseRuntimeElementCompositeDefinition definition =
         context.getResourceDefinition(type);
 
+    List<BaseRuntimeElementCompositeDefinition<?>> containedDefinitions = new ArrayList<>();
+
+    for (Class resource : contained) {
+
+      containedDefinitions.add(context.getResourceDefinition(resource));
+    }
+
+    StringBuilder keyBuilder = new StringBuilder(type.getName());
+
+    for (Class resource : contained) {
+
+      keyBuilder.append(resource.getName());
+    }
+
+    int key = keyBuilder.toString().hashCode();
+
     synchronized (encoderCache) {
 
-      ExpressionEncoder<T> encoder = encoderCache.get(type);
+      ExpressionEncoder<T> encoder = encoderCache.get(key);
 
       if (encoder == null) {
 
@@ -191,13 +215,28 @@ public class FhirEncoders {
             EncoderBuilder.of(definition,
                 context,
                 mappings,
-                new SchemaConverter(context, mappings));
+                new SchemaConverter(context, mappings),
+                JavaConversions.asScalaBuffer(containedDefinitions));
 
-        encoderCache.put(type, encoder);
+        encoderCache.put(key, encoder);
       }
 
       return encoder;
     }
+  }
+
+  /**
+   * Returns an encoder for the given FHIR resource.
+   *
+   * @param type the type of the resource to encode.
+   * @param contained a list of types for FHIR resources contained to the encoded resource.
+   * @param <T> the type of the resource to be encoded.
+   * @return an encoder for the resource.
+   */
+  public final <T extends IBaseResource> ExpressionEncoder<T> of(Class<T> type,
+      Class... contained) {
+
+    return of(type, Arrays.asList(contained));
   }
 
   /**
@@ -206,14 +245,23 @@ public class FhirEncoders {
    *
    * @param resourceName the name of the FHIR resource to encode, such as
    *     "Encounter", "Condition", "Observation", etc.
+   * @param contained the names of FHIR resources contained to the encoded resource.
    * @param <T> the type of the resource to be encoded.
    * @return an encoder for the resource.
    */
-  public <T extends IBaseResource> ExpressionEncoder<T> of(String resourceName) {
+  public <T extends IBaseResource> ExpressionEncoder<T> of(String resourceName,
+      String... contained) {
 
     RuntimeResourceDefinition definition = context.getResourceDefinition(resourceName);
 
-    return of((Class<T>) definition.getImplementingClass());
+    List<Class> containedClasses = new ArrayList<>();
+
+    for (String containedName : contained) {
+
+      containedClasses.add(context.getResourceDefinition(containedName).getImplementingClass());
+    }
+
+    return of((Class<T>) definition.getImplementingClass(), containedClasses);
   }
 
   /**

--- a/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
@@ -182,9 +182,8 @@ public class FhirEncoders {
    * @param <T> the type of the resource to be encoded.
    * @return an encoder for the resource.
    */
-  public final <T extends IBaseResource> ExpressionEncoder<T> of (Class<T> type,
+  public final <T extends IBaseResource> ExpressionEncoder<T> of(Class<T> type,
       List<Class> contained) {
-
 
     BaseRuntimeElementCompositeDefinition definition =
         context.getResourceDefinition(type);

--- a/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/FhirEncoders.java
@@ -173,7 +173,6 @@ public class FhirEncoders {
     return new Builder(fhirVersion);
   }
 
-
   /**
    * Returns an encoder for the given FHIR resource.
    *
@@ -183,7 +182,7 @@ public class FhirEncoders {
    * @return an encoder for the resource.
    */
   public final <T extends IBaseResource> ExpressionEncoder<T> of(Class<T> type,
-      List<Class> contained) {
+      List<Class<? extends IBaseResource>> contained) {
 
     BaseRuntimeElementCompositeDefinition definition =
         context.getResourceDefinition(type);
@@ -233,7 +232,7 @@ public class FhirEncoders {
    * @return an encoder for the resource.
    */
   public final <T extends IBaseResource> ExpressionEncoder<T> of(Class<T> type,
-      Class... contained) {
+      Class<? extends IBaseResource>... contained) {
 
     return of(type, Arrays.asList(contained));
   }
@@ -253,7 +252,7 @@ public class FhirEncoders {
 
     RuntimeResourceDefinition definition = context.getResourceDefinition(resourceName);
 
-    List<Class> containedClasses = new ArrayList<>();
+    List<Class<? extends IBaseResource>> containedClasses = new ArrayList<>();
 
     for (String containedName : contained) {
 

--- a/bunsen-core/src/main/scala/com/cerner/bunsen/SchemaConverter.scala
+++ b/bunsen-core/src/main/scala/com/cerner/bunsen/SchemaConverter.scala
@@ -98,4 +98,33 @@ class SchemaConverter(fhirContext: FhirContext, dataTypeMappings: DataTypeMappin
     StructType(fields)
   }
 
+  /**
+    * Returns the Spark struct type used to encode the given parent FHIR composite and any optional
+    * contained FHIR resources.
+    *
+    * @param definition The FHIR definition of the parent having a composite type.
+    * @param contained The FHIR definitions of resources contained to the parent having composite
+    *                  types.
+    * @return The schema of the parent as a Spark StructType
+    */
+  private[bunsen] def parentToStructType(definition: BaseRuntimeElementCompositeDefinition[_],
+                                         contained: Seq[BaseRuntimeElementCompositeDefinition[_]]): StructType = {
+
+    val parent = compositeToStructType(definition)
+
+    if (contained.nonEmpty) {
+      val containedFields = contained.map(containedElement =>
+        StructField(containedElement.getName,
+          compositeToStructType(containedElement)))
+
+      val containedStruct = StructType(containedFields)
+
+      parent.add(StructField("contained", containedStruct))
+
+    } else {
+
+      parent
+    }
+  }
+
 }

--- a/bunsen-core/src/main/scala/com/cerner/bunsen/SchemaConverter.scala
+++ b/bunsen-core/src/main/scala/com/cerner/bunsen/SchemaConverter.scala
@@ -126,5 +126,4 @@ class SchemaConverter(fhirContext: FhirContext, dataTypeMappings: DataTypeMappin
       parent
     }
   }
-
 }

--- a/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
+++ b/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
@@ -119,7 +119,6 @@ public class TestData {
     return patient;
   }
 
-
   /**
    * Returns a FHIR medication to be contained to a medication request for testing purposes.
    */

--- a/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
+++ b/bunsen-r4/src/test/java/com/cerner/bunsen/r4/TestData.java
@@ -1,5 +1,6 @@
 package com.cerner.bunsen.r4;
 
+import com.google.common.collect.ImmutableList;
 import org.hl7.fhir.r4.model.Annotation;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -7,10 +8,14 @@ import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Medication;
+import org.hl7.fhir.r4.model.Medication.MedicationIngredientComponent;
 import org.hl7.fhir.r4.model.MedicationRequest;
 import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Provenance;
+import org.hl7.fhir.r4.model.Provenance.ProvenanceEntityRole;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.codesystems.ConditionVerStatus;
@@ -114,6 +119,48 @@ public class TestData {
     return patient;
   }
 
+
+  /**
+   * Returns a FHIR medication to be contained to a medication request for testing purposes.
+   */
+  public static Medication newMedication() {
+
+    Medication medication = new Medication();
+
+    medication.setId("test-med");
+
+    MedicationIngredientComponent ingredient = new MedicationIngredientComponent();
+
+    CodeableConcept item = new CodeableConcept();
+    item.addCoding()
+        .setSystem("test/ingredient/system")
+        .setCode("test-code");
+
+    ingredient.setItem(item);
+
+    medication.addIngredient(ingredient);
+
+    return medication;
+  }
+
+  /**
+   * Returns a FHIR Provenance to be contained to a medication request for testing purposes.
+   */
+  public static Provenance newProvenance() {
+
+    Provenance provenance = new Provenance();
+
+    provenance.setId("test-provenance");
+
+    provenance.setTarget(ImmutableList.of(new Reference("test-target")));
+
+    provenance.getEntityFirstRep()
+        .setRole(ProvenanceEntityRole.SOURCE)
+        .setWhat(new Reference("test-entity"));
+
+    return provenance;
+  }
+
   /**
    * Returns a FHIR medication request for testing purposes.
    */
@@ -143,6 +190,10 @@ public class TestData {
             .setDisplay("Example provider."));
 
     medReq.addNote(annotation);
+
+    // Add contained resources
+    medReq.addContained(newMedication());
+    medReq.addContained(newProvenance());
 
     return medReq;
   }

--- a/bunsen-r4/src/test/resources/json/bundles/patient-1032702.fhir-bundle.json
+++ b/bunsen-r4/src/test/resources/json/bundles/patient-1032702.fhir-bundle.json
@@ -72,6 +72,12 @@
     {
       "resource": {
         "resourceType": "MedicationRequest",
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "201"
+          }
+        ],
         "id": "101",
         "text": {
           "status": "generated",

--- a/bunsen-r4/src/test/resources/json/bundles/patient-6666001.fhir-bundle.json
+++ b/bunsen-r4/src/test/resources/json/bundles/patient-6666001.fhir-bundle.json
@@ -54,6 +54,12 @@
     {
       "resource": {
         "resourceType": "MedicationRequest",
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "202"
+          }
+        ],
         "id": "353",
         "text": {
           "status": "generated",

--- a/bunsen-r4/src/test/resources/xml/bundles/patient-1032702.fhir-bundle.xml
+++ b/bunsen-r4/src/test/resources/xml/bundles/patient-1032702.fhir-bundle.xml
@@ -67,6 +67,11 @@
 
       <MedicationRequest>
         <id value="101"/>
+        <contained>
+          <Medication>
+            <id value="201"/>
+          </Medication>
+        </contained>
         <text>
           <status value="generated"/>
           <div xmlns="http://www.w3.org/1999/xhtml">

--- a/bunsen-r4/src/test/resources/xml/bundles/patient-6666001.fhir-bundle.xml
+++ b/bunsen-r4/src/test/resources/xml/bundles/patient-6666001.fhir-bundle.xml
@@ -95,6 +95,11 @@
 
       <MedicationRequest>
         <id value="354"/>
+        <contained>
+          <Medication>
+            <id value="202"/>
+          </Medication>
+        </contained>
         <text>
           <status value="generated"/>
           <div xmlns="http://www.w3.org/1999/xhtml">

--- a/bunsen-stu3/src/main/scala/com/cerner/bunsen/stu3/Stu3DataTypeMappings.scala
+++ b/bunsen-stu3/src/main/scala/com/cerner/bunsen/stu3/Stu3DataTypeMappings.scala
@@ -106,7 +106,7 @@ class Stu3DataTypeMappings extends DataTypeMappings {
   override def skipField(definition: BaseRuntimeElementCompositeDefinition[_],
                 child: BaseRuntimeChildDefinition ) : Boolean = {
 
-    // References may be recursive, so include only the reference adn display name.
+    // References may be recursive, so include only the reference and display name.
     val skipRecursiveReference = definition.getImplementingClass == classOf[Reference] &&
       !(child.getElementName == "reference" ||
         child.getElementName == "display")

--- a/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/BundlesTest.java
+++ b/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/BundlesTest.java
@@ -12,8 +12,10 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Condition;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -130,6 +132,22 @@ public class BundlesTest {
     Assert.assertTrue(conditionIds.containsAll(expectedIds));
   }
 
+  private void checkContained(Dataset<MedicationRequest> medicationRequests) {
+    List<String> medicationIds = medicationRequests
+        .select("contained.medication.id")
+        .where(functions.col("id").isNotNull())
+        .as(Encoders.STRING())
+        .collectAsList();
+
+    Assert.assertEquals(2, medicationIds.size());
+
+    List<String> expectedIds = ImmutableList.of(
+        "#201",
+        "#202");
+
+    Assert.assertTrue(medicationIds.containsAll(expectedIds));
+  }
+
   @Test
   public void testGetResourcesByClass() {
 
@@ -158,6 +176,17 @@ public class BundlesTest {
 
     checkPatients(patients);
     checkConditions(conditions);
+  }
+
+  @Test
+  public void getContained() {
+
+    Dataset<MedicationRequest> medicationRequests = bundles.extractEntry(spark,
+        bundlesRdd,
+        "MedicationRequest",
+        "Medication");
+
+    checkContained(medicationRequests);
   }
 
   @Test

--- a/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/FhirEncodersTest.java
+++ b/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/FhirEncodersTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -18,11 +19,18 @@ import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Medication;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Procedure;
+import org.hl7.fhir.dstu3.model.Provenance;
+import org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityComponent;
 import org.hl7.fhir.dstu3.model.Quantity;
+import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IBaseReference;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -75,8 +83,7 @@ public class FhirEncodersTest {
     decodedObservation = observationsDataset.head();
 
     medDataset = spark.createDataset(ImmutableList.of(medRequest),
-        encoders.of(MedicationRequest.class));
-
+        encoders.of(MedicationRequest.class, Medication.class, Provenance.class));
     decodedMedRequest = medDataset.head();
   }
 
@@ -225,6 +232,42 @@ public class FhirEncodersTest {
     Assert.assertEquals(original.getAuthorReference().getReference(),
         decoded.getAuthorReference().getReference());
 
+  }
+
+  @Test
+  public void contained() throws FHIRException {
+
+    // Contained resources should be put to the Contained list in order of the Encoder arguments
+    Assert.assertTrue(decodedMedRequest.getContained().get(0) instanceof Medication);
+
+    Medication originalMedication = (Medication) medRequest.getContained().get(0);
+    Medication decodedMedication = (Medication) decodedMedRequest.getContained().get(0);
+
+    Assert.assertEquals(originalMedication.getId(), decodedMedication.getId());
+    Assert.assertEquals(originalMedication.getIngredientFirstRep()
+            .getItemCodeableConcept()
+            .getCodingFirstRep()
+            .getCode(),
+        decodedMedication.getIngredientFirstRep()
+            .getItemCodeableConcept()
+            .getCodingFirstRep()
+            .getCode());
+
+    Assert.assertTrue(decodedMedRequest.getContained().get(1) instanceof Provenance);
+
+    Provenance decodedProvenance = (Provenance) decodedMedRequest.getContained().get(1);
+    Provenance originalProvenance = (Provenance) medRequest.getContained().get(1);
+
+    Assert.assertEquals(originalProvenance.getId(), decodedProvenance.getId());
+    Assert.assertEquals(originalProvenance.getTargetFirstRep().getReference(),
+        decodedProvenance.getTargetFirstRep().getReference());
+
+    ProvenanceEntityComponent originalEntity = originalProvenance.getEntityFirstRep();
+    ProvenanceEntityComponent decodedEntity = decodedProvenance.getEntityFirstRep();
+
+    Assert.assertEquals(originalEntity.getRole(), decodedEntity.getRole());
+    Assert.assertEquals(originalEntity.getWhatReference().getReference(),
+        decodedEntity.getWhatReference().getReference());
   }
 
   /**

--- a/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
+++ b/bunsen-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
@@ -1,15 +1,22 @@
 package com.cerner.bunsen.stu3;
 
+import com.google.common.collect.ImmutableList;
 import org.hl7.fhir.dstu3.model.Annotation;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Medication;
+import org.hl7.fhir.dstu3.model.Medication.MedicationIngredientComponent;
+import org.hl7.fhir.dstu3.model.Medication.MedicationStatus;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Narrative;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Procedure;
+import org.hl7.fhir.dstu3.model.Provenance;
+import org.hl7.fhir.dstu3.model.Provenance.ProvenanceEntityRole;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.utilities.xhtml.NodeType;
@@ -109,13 +116,54 @@ public class TestData {
   }
 
   /**
+   * Returns a FHIR medication to be contained to a medication request for testing purposes.
+   */
+  public static Medication newMedication() {
+
+    Medication medication = new Medication();
+
+    medication.setId("test-med");
+
+    MedicationIngredientComponent ingredient = new MedicationIngredientComponent();
+
+    CodeableConcept item = new CodeableConcept();
+    item.addCoding()
+        .setSystem("test/ingredient/system")
+        .setCode("test-code");
+
+    ingredient.setItem(item);
+
+    medication.addIngredient(ingredient);
+
+    return medication;
+  }
+
+  /**
+   * Returns a FHIR Provenance to be contained to a medication request for testing purposes.
+   */
+  public static Provenance newProvenance() {
+
+    Provenance provenance = new Provenance();
+
+    provenance.setId("test-provenance");
+
+    provenance.setTarget(ImmutableList.of(new Reference("test-target")));
+
+    provenance.getEntityFirstRep()
+        .setRole(ProvenanceEntityRole.SOURCE)
+        .setWhat(new Reference("test-entity"));
+
+    return provenance;
+  }
+
+  /**
    * Returns a FHIR medication request for testing purposes.
    */
   public static MedicationRequest newMedRequest() {
 
     MedicationRequest medReq = new MedicationRequest();
 
-    medReq.setId("test-med");
+    medReq.setId("test-medreq");
 
     // Medication code
     CodeableConcept med = new CodeableConcept();
@@ -137,6 +185,10 @@ public class TestData {
             .setDisplay("Example provider."));
 
     medReq.addNote(annotation);
+
+    // Add contained resources
+    medReq.addContained(newMedication());
+    medReq.addContained(newProvenance());
 
     return medReq;
   }

--- a/bunsen-stu3/src/test/resources/json/bundles/patient-1032702.fhir-bundle.json
+++ b/bunsen-stu3/src/test/resources/json/bundles/patient-1032702.fhir-bundle.json
@@ -72,6 +72,12 @@
     {
       "resource": {
         "resourceType": "MedicationRequest",
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "201"
+          }
+        ],
         "id": "101",
         "text": {
           "status": "generated",

--- a/bunsen-stu3/src/test/resources/json/bundles/patient-6666001.fhir-bundle.json
+++ b/bunsen-stu3/src/test/resources/json/bundles/patient-6666001.fhir-bundle.json
@@ -54,6 +54,12 @@
     {
       "resource": {
         "resourceType": "MedicationRequest",
+        "contained": [
+          {
+            "resourceType": "Medication",
+            "id": "202"
+          }
+        ],
         "id": "353",
         "text": {
           "status": "generated",

--- a/bunsen-stu3/src/test/resources/xml/bundles/patient-1032702.fhir-bundle.xml
+++ b/bunsen-stu3/src/test/resources/xml/bundles/patient-1032702.fhir-bundle.xml
@@ -67,6 +67,11 @@
 
       <MedicationRequest>
         <id value="101"/>
+        <contained>
+          <Medication>
+            <id value="201"/>
+          </Medication>
+        </contained>
         <text>
           <status value="generated"/>
           <div xmlns="http://www.w3.org/1999/xhtml">

--- a/bunsen-stu3/src/test/resources/xml/bundles/patient-6666001.fhir-bundle.xml
+++ b/bunsen-stu3/src/test/resources/xml/bundles/patient-6666001.fhir-bundle.xml
@@ -53,6 +53,11 @@
 
       <MedicationRequest>
         <id value="353"/>
+         <contained>
+          <Medication>
+            <id value="202"/>
+          </Medication>
+        </contained>
         <text>
           <status value="generated"/>
           <div xmlns="http://www.w3.org/1999/xhtml">

--- a/python/bunsen/r4/bundles.py
+++ b/python/bunsen/r4/bundles.py
@@ -76,7 +76,7 @@ def extract_entry(sparkSession, javaRDD, resourceName):
             bundles.extractEntry(sparkSession._jsparkSession, javaRDD, resourceName),
             sparkSession._wrapped)
 
-def extract_entry(sparkSession, javaRDD, resourceName):
+def extract_entry(sparkSession, javaRDD, resourceName, contained=[]):
     """
     Returns a dataset for the given entry type from the bundles.
 
@@ -85,13 +85,21 @@ def extract_entry(sparkSession, javaRDD, resourceName):
         in this package
     :param resourceName: the name of the FHIR resource to extract
         (condition, observation, etc)
+    :param contained: the list of names of the FHIR resources contained to the parent
+        resource
     :return: a DataFrame containing the given resource encoded into Spark columns
     """
 
+    jArray = sparkSession.sparkContext._gateway \
+        .new_array(sparkSession._jvm.java.lang.String, len(contained))
+
+    for idx, c in enumerate(contained):
+        jArray[idx] = contained[idx]
+
     bundles = _bundles(sparkSession._jvm)
     return DataFrame(
-        bundles.extractEntry(sparkSession._jsparkSession, javaRDD, resourceName),
-        sparkSession._wrapped)
+            bundles.extractEntry(sparkSession._jsparkSession, javaRDD, resourceName, jArray),
+            sparkSession._wrapped)
 
 def write_to_database(sparkSession, javaRDD, databaseName, resourceNames):
     """

--- a/python/bunsen/stu3/bundles.py
+++ b/python/bunsen/stu3/bundles.py
@@ -59,7 +59,7 @@ def from_xml(df, column):
     bundles = _bundles(df._sc._jvm)
     return bundles.fromXml(df._jdf, column)
 
-def extract_entry(sparkSession, javaRDD, resourceName):
+def extract_entry(sparkSession, javaRDD, resourceName, contained=[]):
     """
     Returns a dataset for the given entry type from the bundles.
 
@@ -68,12 +68,20 @@ def extract_entry(sparkSession, javaRDD, resourceName):
         in this package
     :param resourceName: the name of the FHIR resource to extract
         (condition, observation, etc)
+    :param contained: the list of names of the FHIR resources contained to the parent
+        resource
     :return: a DataFrame containing the given resource encoded into Spark columns
     """
 
+    jArray = sparkSession.sparkContext._gateway \
+        .new_array(sparkSession._jvm.java.lang.String, len(contained))
+
+    for idx, c in enumerate(contained):
+        jArray[idx] = contained[idx]
+
     bundles = _bundles(sparkSession._jvm)
     return DataFrame(
-            bundles.extractEntry(sparkSession._jsparkSession, javaRDD, resourceName),
+            bundles.extractEntry(sparkSession._jsparkSession, javaRDD, resourceName, jArray),
             sparkSession._wrapped)
 
 def write_to_database(sparkSession, javaRDD, databaseName, resourceNames):


### PR DESCRIPTION
## Description

Resolves #46. 

Adds support for Contained Resources by allowing the user to declare a static listing of Resources that will be Contained. `Encoder` functions are then generated to inline Contained Resources to the Parent resource.

FHIR views Contained Resources as a List having a `Resource` type. Spark Schema won't meaningfully understand that parent type, so we create a "contained" struct having a field for each declared Resource type to serialize to. Deserialization puts the elements of the Struct back into the FHIR Contained list.

## Tests

Tested by adding new unit tests. Ran a Jupyter session testing the `extract_entry` method over both STU3 and R4 content for bundles having Contained resources.