### PR TITLE
Fix for FHIR resource object instantiation issue

### DIFF
--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -243,4 +243,13 @@ public class SpecificRecordsTest {
     Assert.assertEquals(testText, ethnicityRecord.getText());
   }
 
+  @Test
+  public void testInstantiationUsingBuilder() {
+
+    Patient obj = Patient.newBuilder()
+        .setId("123").build();
+    Assert.assertEquals("123", obj.getId());
+    Assert.assertEquals(null, obj.getGender());
+  }
+
 }

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -290,7 +291,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
    */
   private static Schema nullable(Schema schema) {
 
-    return Schema.createUnion(Arrays.asList(schema, NULL_SCHEMA));
+    return Schema.createUnion(Arrays.asList(NULL_SCHEMA, schema));
   }
 
   @Override
@@ -318,7 +319,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
             return new Field(field.fieldName(),
                 nullable(field.result().getDataType()),
                 doc,
-                (Object) null);
+                JsonProperties.NULL_VALUE);
 
           }).collect(Collectors.toList());
 


### PR DESCRIPTION

### Summary
Any FHIR resource object instantiation fails, when its constructed using the corresponding FHIR Avro schema's builder method.

### Additional Details
The following exception occurs when the "default" value is not set for fields in generated/source avpr file

```
org.apache.avro.AvroRuntimeException: org.apache.avro.AvroRuntimeException: Field meta type:UNION pos:1 not set and has no default value

	at com.cerner.bunsen.stu3.avro.Patient$Builder.build(Patient.java:2246)
```

Following links suggests the implemented solution
[1] https://stackoverflow.com/questions/22938124/avro-field-default-values
[2] https://avro.apache.org/docs/1.8.2/spec.html#Unions
