### PR TITLE
issue-55: bumping pyspark

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-pyspark==2.3
+pyspark==2.4.4


### PR DESCRIPTION
Closes #55 and bumps PySpark for Spark 2.4.4.

Follows up #54.