### PR TITLE
[issue-58] adding identical ChoiceType support and tests, upgrading to…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 cache:
   directories:
   - "$HOME/.m2"

--- a/bunsen-avro-records-stu3/pom.xml
+++ b/bunsen-avro-records-stu3/pom.xml
@@ -139,19 +139,29 @@
 
             <!-- Base Resources -->
             <argument>http://hl7.org/fhir/StructureDefinition/Patient</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/Observation</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/Condition</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/AllergyIntolerance</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/Procedure</argument>
-
+            <argument>http://hl7.org/fhir/StructureDefinition/CarePlan</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Claim</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Condition</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Encounter</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/EpisodeOfCare</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Immunization</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Measure</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/MeasureReport</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Medication</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationDispense</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/MedicationRequest</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationStatement</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/MedicationRequest</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/ProcedureRequest</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Observation</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/Procedure</argument>
 
             <!-- US Core Resources -->
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient</argument>
+            <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan</argument>
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition</argument>
+            <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter</argument>
+            <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization</argument>
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication</argument>
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest</argument>
           </arguments>

--- a/bunsen-avro-records-stu3/pom.xml
+++ b/bunsen-avro-records-stu3/pom.xml
@@ -144,12 +144,16 @@
             <argument>http://hl7.org/fhir/StructureDefinition/AllergyIntolerance</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Procedure</argument>
 
+            <argument>http://hl7.org/fhir/StructureDefinition/Medication</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/MedicationDispense</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationRequest</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationStatement</argument>
 
             <!-- US Core Resources -->
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient</argument>
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition</argument>
+            <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication</argument>
+            <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest</argument>
           </arguments>
 
         </configuration>

--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -13,7 +13,6 @@ import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.Quantity;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,13 +37,13 @@ public class SpecificRecordsTest {
   private static final AvroConverter OBSERVATION_CONVERTER =
       AvroConverter.forResource(FhirContexts.forStu3(), "Observation");
 
-  private static final org.hl7.fhir.dstu3.model.Observation testObservation
-      = TestData.newObservation();
+  private static final org.hl7.fhir.dstu3.model.Observation testObservation =
+      TestData.newObservation();
 
-  public static Observation avroObservation =
+  private static final Observation avroObservation =
       (Observation) OBSERVATION_CONVERTER.resourceToAvro(testObservation);
 
-  private static org.hl7.fhir.dstu3.model.Observation testObservationDecoded =
+  private static final org.hl7.fhir.dstu3.model.Observation testObservationDecoded =
       (org.hl7.fhir.dstu3.model.Observation) OBSERVATION_CONVERTER.avroToResource(avroObservation);
 
   private static final AvroConverter CONDITION_CONVERTER =
@@ -52,12 +51,25 @@ public class SpecificRecordsTest {
 
   private static final org.hl7.fhir.dstu3.model.Condition testCondition = TestData.newCondition();
 
-  public static com.cerner.bunsen.stu3.avro.us.core.Condition avroCondition =
-      (com.cerner.bunsen.stu3.avro.us.core.Condition) CONDITION_CONVERTER.resourceToAvro(testCondition);
+  private static final com.cerner.bunsen.stu3.avro.us.core.Condition avroCondition =
+      (com.cerner.bunsen.stu3.avro.us.core.Condition) CONDITION_CONVERTER
+          .resourceToAvro(testCondition);
 
-  private static org.hl7.fhir.dstu3.model.Condition  testConditionDecoded =
-      (org.hl7.fhir.dstu3.model.Condition ) CONDITION_CONVERTER.avroToResource(avroCondition);
+  private static final org.hl7.fhir.dstu3.model.Condition  testConditionDecoded =
+      (org.hl7.fhir.dstu3.model.Condition) CONDITION_CONVERTER.avroToResource(avroCondition);
 
+  private static final AvroConverter MEDICATION_CONVERTER =
+      AvroConverter.forResource(FhirContexts.forStu3(), TestData.US_CORE_MEDICATION);
+
+  private static final org.hl7.fhir.dstu3.model.Medication testMedication =
+      TestData.newMedication();
+
+  private static final com.cerner.bunsen.stu3.avro.us.core.Medication avroMedication =
+      (com.cerner.bunsen.stu3.avro.us.core.Medication) MEDICATION_CONVERTER
+          .resourceToAvro(testMedication);
+
+  private static final org.hl7.fhir.dstu3.model.Medication testMedicationDecoded =
+      (org.hl7.fhir.dstu3.model.Medication) MEDICATION_CONVERTER.avroToResource(avroMedication);
 
   @Test
   public void testInteger() {
@@ -99,7 +111,7 @@ public class SpecificRecordsTest {
   }
 
   @Test
-  public void testChoice() throws FHIRException {
+  public void testChoice() {
 
     // Ensure that a decoded choice type matches the original
     Assert.assertTrue(testPatient.getMultipleBirth()
@@ -110,6 +122,22 @@ public class SpecificRecordsTest {
 
     // Choice types not populated should be null.
     Assert.assertNull(avroPatient.getMultipleBirth().getBoolean$());
+  }
+
+  /**
+   * Tests that FHIR StructureDefinitions that contain fields having identical ChoiceTypes generate
+   * an Avro definition that does not trigger an erroneous re-definition of the Avro, and that the
+   * converter functions can populate the separate fields even when they share an underlying Avro
+   * class for the ChoiceType.
+   */
+  @Test
+  public void testIdenticalChoicesTypes() {
+
+    Assert.assertTrue(testMedication.getIngredientFirstRep()
+        .equalsDeep(testMedicationDecoded.getIngredientFirstRep()));
+
+    Assert.assertTrue(testMedication.getPackage().getContentFirstRep()
+        .equalsDeep(testMedicationDecoded.getPackage().getContentFirstRep()));
   }
 
   @Test

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -31,6 +31,7 @@ import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
@@ -40,7 +41,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
   private final String basePackage;
 
-  private final Map<String, HapiConverter<Schema>> compositeConverters;
+  private final Map<String, HapiConverter<Schema>> visitedConverters;
 
   private static final HapiConverter STRING_CONVERTER =
       new StringConverter(Schema.create(Type.STRING));
@@ -266,16 +267,16 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
    *
    * @param fhirSupport support for FHIR conversions.
    * @param basePackage the base package to be used for generated Avro structures.
-   * @param compositeConverters a mutable cache of generated converters that may
+   * @param visitedConverters a mutable cache of generated converters that may
    *     be reused by types that contain them.
    */
   public DefinitionToAvroVisitor(FhirConversionSupport fhirSupport,
       String basePackage,
-      Map<String,HapiConverter<Schema>> compositeConverters) {
+      Map<String,HapiConverter<Schema>> visitedConverters) {
 
     this.fhirSupport = fhirSupport;
     this.basePackage = basePackage;
-    this.compositeConverters = compositeConverters;
+    this.visitedConverters = visitedConverters;
   }
 
   @Override
@@ -305,7 +306,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
     String recordNamespace = namespaceFor(elementTypeUrl);
     String fullName = recordNamespace + "." + recordName;
 
-    HapiConverter<Schema> converter = compositeConverters.get(fullName);
+    HapiConverter<Schema> converter = visitedConverters.get(fullName);
 
     if (converter == null) {
 
@@ -332,7 +333,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       converter = new CompositeToAvroConverter(baseType,
           children, schema, fhirSupport);
 
-      compositeConverters.put(fullName, converter);
+      visitedConverters.put(fullName, converter);
     }
 
     return converter;
@@ -405,7 +406,10 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
   private String recordNameFor(String elementPath) {
 
-    return elementPath.replaceAll("\\.", "");
+    return Arrays.stream(elementPath.split("\\."))
+        .map(StringUtils::capitalize)
+        .reduce(String::concat)
+        .get();
   }
 
   private String namespaceFor(String structuctureDefinitionUrl) {
@@ -442,7 +446,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
     String fullName = basePackage + "." + recordName;
 
-    HapiConverter<Schema> converter = compositeConverters.get(fullName);
+    HapiConverter<Schema> converter = visitedConverters.get(fullName);
 
     if (converter == null) {
 
@@ -480,7 +484,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           schema,
           fhirSupport);
 
-      compositeConverters.put(fullName, converter);
+      visitedConverters.put(fullName, converter);
     }
 
     return converter;
@@ -496,7 +500,6 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       return null;
     }
 
-
     String recordNamespace = namespaceFor(extensionUrl);
 
     String localPart = extensionUrl.substring(extensionUrl.lastIndexOf('/') + 1);
@@ -509,7 +512,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
     String fullName = recordNamespace + "." + recordName;
 
-    HapiConverter<Schema> converter = compositeConverters.get(fullName);
+    HapiConverter<Schema> converter = visitedConverters.get(fullName);
 
     if (converter == null) {
 
@@ -532,7 +535,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           fhirSupport,
           extensionUrl);
 
-      compositeConverters.put(fullName, converter);
+      visitedConverters.put(fullName, converter);
     }
 
     return converter;
@@ -578,15 +581,25 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
             .map(DefinitionToAvroVisitor::capitalize)
             .collect(Collectors.joining());
 
-    Schema schema = Schema.createRecord("Choice" + fieldTypesString,
-        "Structure for FHIR choice type ",
-        basePackage,
-        false, fields);
+    String fullName = basePackage + "." + "Choice" + fieldTypesString;
 
-    return new ChoiceToAvroConverter(choiceTypes,
-        schema,
-        fhirSupport);
+    HapiConverter<Schema> converter = visitedConverters.get(fullName);
 
+    if (converter == null) {
+
+      Schema schema = Schema.createRecord("Choice" + fieldTypesString,
+          "Structure for FHIR choice type ",
+          basePackage,
+          false, fields);
+
+      converter = new ChoiceToAvroConverter(choiceTypes,
+          schema,
+          fhirSupport);
+
+      visitedConverters.put(fullName, converter);
+    }
+
+    return converter;
   }
 
   private static final String capitalize(String string) {
@@ -608,8 +621,6 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
     return Character.toLowerCase(string.charAt(0)) + string.substring(1);
   }
-
-
 
   @Override
   public int getMaxDepth(String elementTypeUrl, String path) {

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -578,7 +578,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
             .keySet()
             .stream()
             .sorted()
-            .map(DefinitionToAvroVisitor::capitalize)
+            .map(StringUtils::capitalize)
             .collect(Collectors.joining());
 
     String fullName = basePackage + "." + "Choice" + fieldTypesString;
@@ -600,16 +600,6 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
     }
 
     return converter;
-  }
-
-  private static final String capitalize(String string) {
-
-    if (string.length() == 0) {
-
-      return string;
-    }
-
-    return Character.toUpperCase(string.charAt(0)) + string.substring(1);
   }
 
   private static final String lowercase(String string) {

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
@@ -21,7 +21,9 @@ public class GenerateSchemasTest {
     int result = GenerateSchemas.main(new String[]
         {outputFile.toString(),
             TestData.US_CORE_PATIENT,
-            TestData.US_CORE_CONDITION});
+            TestData.US_CORE_CONDITION,
+            TestData.US_CORE_MEDICATION,
+            TestData.MEDICATION_REQUEST});
 
     Assert.assertEquals(0, result);
 

--- a/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -506,6 +506,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
             return targetDefinition.getType();
           })
+          .sorted()
           .collect(Collectors.toList());
 
       return visitor.visitReference(rootName, referenceTypes, childElements);

--- a/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
+++ b/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
@@ -11,6 +11,10 @@ import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Medication;
+import org.hl7.fhir.dstu3.model.Medication.MedicationIngredientComponent;
+import org.hl7.fhir.dstu3.model.Medication.MedicationPackageComponent;
+import org.hl7.fhir.dstu3.model.Medication.MedicationPackageContentComponent;
 import org.hl7.fhir.dstu3.model.Narrative;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationComponentComponent;
@@ -41,11 +45,19 @@ public class TestData {
   public static final String US_CORE_CONDITION =
       "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition";
 
+  public static final String US_CORE_MEDICATION =
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication";
+
+  public static final String MEDICATION_REQUEST =
+      "http://hl7.org/fhir/StructureDefinition/MedicationRequest";
+
   public static final String VALUE_SET =
       "http://hl7.org/fhir/StructureDefinition/ValueSet";
 
   /**
    * Returns a FHIR Condition for testing purposes.
+   *
+   * @return a FHIR Condition for testing.
    */
   public static Condition newCondition() {
 
@@ -96,9 +108,9 @@ public class TestData {
   }
 
   /**
-   * Returns a new observation for testing.
+   * Returns a new Observation for testing.
    *
-   * @return a FHIR observation for testing.
+   * @return a FHIR Observation for testing.
    */
   public static Observation newObservation() {
     Observation observation = new Observation();
@@ -111,9 +123,7 @@ public class TestData {
 
     observation.setStatus(Observation.ObservationStatus.FINAL);
 
-
     CodeableConcept obsCode = new CodeableConcept();
-
 
     observation.setCode(obsCode);
 
@@ -138,7 +148,7 @@ public class TestData {
   /**
    * Returns a new Patient for testing.
    *
-   * @return a FHIR patient for testing.
+   * @return a FHIR Patient for testing.
    */
   public static Patient newPatient() {
 
@@ -187,6 +197,43 @@ public class TestData {
     ethnicityText.setValue(new StringType("Not Hispanic or Latino"));
 
     return patient;
+  }
+
+  /**
+   * Returns a new Medication for testing.
+   *
+   * @return a FHIR Medication for testing.
+   */
+  public static Medication newMedication() {
+
+    Medication medication = new Medication();
+
+    medication.setId("test-medication");
+
+    CodeableConcept itemCodeableConcept = new CodeableConcept();
+    itemCodeableConcept.addCoding()
+        .setSystem("http://www.nlm.nih.gov/research/umls/rxnorm")
+        .setCode("103109")
+        .setDisplay("Vitamin E 3 MG Oral Tablet [Ephynal]")
+        .setUserSelected(true);
+
+    MedicationIngredientComponent ingredientComponent = new MedicationIngredientComponent();
+    ingredientComponent.setItem(itemCodeableConcept);
+
+    medication.addIngredient(ingredientComponent);
+
+    Reference itemReference = new Reference("test-item-reference");
+
+    MedicationPackageContentComponent medicationPackageContentComponent =
+        new MedicationPackageContentComponent();
+    medicationPackageContentComponent.setItem(itemReference);
+
+    MedicationPackageComponent medicationPackageComponent = new MedicationPackageComponent();
+    medicationPackageComponent.addContent(medicationPackageContentComponent);
+
+    medication.setPackage(medicationPackageComponent);
+
+    return medication;
   }
 
 }

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
@@ -23,10 +23,9 @@ public abstract class HapiConverter<T> {
      * @param fieldToSet the runtime definition of the field to set.
      * @param value the value to be converted and set on the FHIR object.
      */
-    public void setField(IBase parentObject,
+    void setField(IBase parentObject,
         BaseRuntimeChildDefinition fieldToSet,
         Object value);
-
   }
 
   /**
@@ -49,7 +48,7 @@ public abstract class HapiConverter<T> {
   }
 
   /**
-   * Converts a HAPI object or list of objects to the equiavelent
+   * Converts a HAPI object or list of objects to the equivalent
    * in the alternative data model
    *
    * @param input a HAPI object.
@@ -84,9 +83,9 @@ public abstract class HapiConverter<T> {
   }
 
   /**
-   * Returns a field setter to be used when converting a Spark object
-   * to HAPI. Choice types may have multiple element definitions, but
-   * in the common case there will be only one.
+   * Returns a field setter to be used when converting an object of an
+   * alternative model to HAPI. Choice types may have multiple element
+   * definitions, but in the common case there will be only one.
    *
    * @param elementDefinitions the set of element definitions that the element can be.
    * @return the field setter.

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
@@ -143,7 +143,6 @@ public class SparkRowConverterTest {
     // Ensure that a decoded choice type matches the original
     Assert.assertTrue(testPatient.getMultipleBirth()
         .equalsDeep(testPatientDecoded.getMultipleBirth()));
-
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,9 @@
     <compile.source>1.8</compile.source>
 
     <!-- Spark -->
-    <spark.version>2.3.0</spark.version>
+    <spark.version>2.4.4</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <parquet.version>1.7.0</parquet.version>
     <hapi.fhir.version>3.3.0</hapi.fhir.version>
     <avro.version>1.8.2</avro.version>
     <junit.version>4.11</junit.version>
@@ -573,13 +572,6 @@
         <artifactId>spark-hive_${scala.binary.version}</artifactId>
         <version>${spark.version}</version>
         <scope>provided</scope>
-      </dependency>
-
-
-      <dependency>
-        <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-avro</artifactId>
-        <version>${parquet.version}</version>
       </dependency>
 
       <!-- FHIR dependencies -->

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-pyspark==2.3
+pyspark==2.4.4


### PR DESCRIPTION
… Spark 2.4.4

### Summary
Closes #58, adding support for Avro Schema generation over FHIR Resources that have fields with identical ChoiceType structures.

### Additional Details
Also bumps the 0.5.0-dev branch to Spark 2.4.4.