### PR TITLE
Make python tests explicitly bind the driver to localhost

### DIFF
--- a/python/tests/test_bunsen_r4.py
+++ b/python/tests/test_bunsen_r4.py
@@ -50,6 +50,7 @@ def spark_session(request):
   spark = SparkSession.builder \
     .appName('bunsen-test') \
     .master('local[2]') \
+    .config('spark.driver.host', 'localhost') \
     .config('spark.jars', shaded_jar) \
     .config('hive.exec.dynamic.partition.mode', 'nonstrict') \
     .config('spark.sql.warehouse.dir', mkdtemp()) \

--- a/python/tests/test_bunsen_stu3.py
+++ b/python/tests/test_bunsen_stu3.py
@@ -50,6 +50,7 @@ def spark_session(request):
   spark = SparkSession.builder \
     .appName('bunsen-test') \
     .master('local[2]') \
+    .config('spark.driver.host', 'localhost') \
     .config('spark.jars', shaded_jar) \
     .config('hive.exec.dynamic.partition.mode', 'nonstrict') \
     .config('spark.sql.warehouse.dir', mkdtemp()) \


### PR DESCRIPTION
This addresses a problem with changing network contexts, and Spark getting confused over which hostname to attempt to bind to.