### PR TITLE
issue-62: add Contained Resource Support

### DIFF
--- a/bunsen-avro-records-stu3/pom.xml
+++ b/bunsen-avro-records-stu3/pom.xml
@@ -148,10 +148,8 @@
             <argument>http://hl7.org/fhir/StructureDefinition/Immunization</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Measure</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MeasureReport</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/Medication</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationDispense</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/MedicationStatement</argument>
-            <argument>http://hl7.org/fhir/StructureDefinition/MedicationRequest</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/ProcedureRequest</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Observation</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Procedure</argument>

--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -58,7 +58,7 @@ public class SpecificRecordsTest {
       (com.cerner.bunsen.stu3.avro.us.core.Condition) CONDITION_CONVERTER
           .resourceToAvro(testCondition);
 
-  private static final org.hl7.fhir.dstu3.model.Condition  testConditionDecoded =
+  private static final org.hl7.fhir.dstu3.model.Condition testConditionDecoded =
       (org.hl7.fhir.dstu3.model.Condition) CONDITION_CONVERTER.avroToResource(avroCondition);
 
   // Medication

--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -66,7 +66,7 @@ public class SpecificRecordsTest {
       AvroConverter.forResource(FhirContexts.forStu3(), TestData.US_CORE_MEDICATION);
 
   private static final org.hl7.fhir.dstu3.model.Medication testMedication =
-      TestData.newMedication();
+      TestData.newMedication("test-medication-1");
 
   private static final com.cerner.bunsen.stu3.avro.us.core.Medication avroMedication =
       (com.cerner.bunsen.stu3.avro.us.core.Medication) MEDICATION_CONVERTER

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
@@ -7,11 +7,14 @@ import com.cerner.bunsen.avro.converters.DefinitionToAvroVisitor;
 import com.cerner.bunsen.definitions.HapiConverter;
 import com.cerner.bunsen.definitions.HapiConverter.HapiObjectConverter;
 import com.cerner.bunsen.definitions.StructureDefinitions;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.IndexedRecord;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -24,18 +27,17 @@ public class AvroConverter {
 
   private final HapiObjectConverter avroToHapiConverter;
 
-  AvroConverter(HapiConverter<Schema> hapiToAvroConverter,
-      RuntimeResourceDefinition resourceDefinition) {
+  private AvroConverter(HapiConverter<Schema> hapiToAvroConverter,
+      RuntimeResourceDefinition... resources) {
 
     this.hapiToAvroConverter = hapiToAvroConverter;
-
-    this.avroToHapiConverter  =
-        (HapiObjectConverter) hapiToAvroConverter.toHapiConverter(resourceDefinition);
+    this.avroToHapiConverter = (HapiObjectConverter) hapiToAvroConverter.toHapiConverter(resources);
   }
 
   private static AvroConverter visitResource(FhirContext context,
       StructureDefinitions structureDefinitions,
       String resourceTypeUrl,
+      List<String> containedResourceTypeUrls,
       Map<String,HapiConverter<Schema>> compositeConverters) {
 
     FhirVersionEnum fhirVersion = context.getVersion().getVersion();
@@ -60,60 +62,102 @@ public class AvroConverter {
                 basePackage,
                 compositeConverters);
 
-    HapiConverter<Schema> converter =  structureDefinitions.transform(visitor, resourceTypeUrl);
+    HapiConverter<Schema> converter =  structureDefinitions.transform(visitor,
+        resourceTypeUrl,
+        containedResourceTypeUrls);
 
-    RuntimeResourceDefinition resourceDefinition =
-        context.getResourceDefinition(converter.getElementType());
+    RuntimeResourceDefinition[] resources =
+        new RuntimeResourceDefinition[1 + containedResourceTypeUrls.size()];
 
-    return new AvroConverter(converter, resourceDefinition);
+    resources[0] = context.getResourceDefinition(converter.getElementType());
+
+    for (int i = 0; i < containedResourceTypeUrls.size(); i++) {
+
+      Field containedField = converter.getDataType()
+          .getField("contained")
+          .schema()
+          .getTypes()
+          .get(1)
+          .getElementType()
+          .getFields()
+          .get(i);
+
+      // Shift array by 1, since the 0 index holds the parent definition
+      resources[i + 1] = context.getResourceDefinition(containedField.name());
+    }
+
+    return new AvroConverter(converter, resources);
   }
 
   /**
    * Returns a list of Avro schemas to support the given FHIR resource types.
    *
    * @param context the FHIR context
-   * @param resourceTypeUrls the URLs of the resource type
+   * @param resourceTypeUrls the URLs of the resource types and any resources URLs contained to them
    * @return a list of Avro schemas
    */
   public static List<Schema> generateSchemas(FhirContext context,
-      List<String> resourceTypeUrls) {
+      Map<String, List<String>> resourceTypeUrls) {
 
     StructureDefinitions structureDefinitions = StructureDefinitions.create(context);
 
-    Map<String,HapiConverter<Schema>> converters = new HashMap<>();
+    Map<String, HapiConverter<Schema>> converters = new HashMap<>();
 
-    for (String resourceTypeUrl: resourceTypeUrls) {
+    for (Entry<String, List<String>> resourceTypeUrlEntry: resourceTypeUrls.entrySet()) {
 
       visitResource(context,
           structureDefinitions,
-          resourceTypeUrl,
+          resourceTypeUrlEntry.getKey(),
+          resourceTypeUrlEntry.getValue(),
           converters);
     }
 
     return converters.values()
         .stream()
-        .map(converter -> converter.getDataType())
+        .map(HapiConverter::getDataType)
         .collect(Collectors.toList());
   }
 
   /**
-   * Returns a row converter for the given resource type. The resource type can
+   * Returns an Avro converter for the given resource type. The resource type can
    * either be a relative URL for a base resource (e.g., "Condition" or "Observation"),
    * or a URL identifying the structure definition for a given profile, such as
    * "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient".
    *
    * @param context the FHIR context
    * @param resourceTypeUrl the URL of the resource type
-   * @return an avro converter instance.
+   * @return an Avro converter instance.
    */
   public static AvroConverter forResource(FhirContext context,
       String resourceTypeUrl) {
+
+    return forResource(context, resourceTypeUrl, Collections.emptyList());
+  }
+
+  /**
+   * Returns an Avro converter for the given resource type. The resource type can
+   * either be a relative URL for a base resource (e.g. "Condition" or "Observation"),
+   * or a URL identifying the structure definition for a given profile, such as
+   * "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient".
+   * <p>
+   * Resources that would be contained must be statically declared through this method
+   * via similar URLs.
+   * </p>
+   * @param context the FHIR context
+   * @param resourceTypeUrl the URL of the resource type
+   * @param containedResourceTypeUrls the list of URLs of contained resource types
+   * @return an Avro converter instance.
+   */
+  public static AvroConverter forResource(FhirContext context,
+      String resourceTypeUrl,
+      List<String> containedResourceTypeUrls) {
 
     StructureDefinitions structureDefinitions = StructureDefinitions.create(context);
 
     return visitResource(context,
         structureDefinitions,
         resourceTypeUrl,
+        containedResourceTypeUrls,
         new HashMap<>());
   }
 

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/AvroConverter.java
@@ -73,11 +73,12 @@ public class AvroConverter {
 
     for (int i = 0; i < containedResourceTypeUrls.size(); i++) {
 
+      // Retrieve the name of the contained resources from the Resource Container's schema
       Field containedField = converter.getDataType()
           .getField("contained")
           .schema()
           .getTypes()
-          .get(1)
+          .get(1) // Get non-null element of the Union
           .getElementType()
           .getFields()
           .get(i);
@@ -162,16 +163,22 @@ public class AvroConverter {
   }
 
   /**
-   * Converts a given FHIR resource to a Spark row.
+   * Converts a given FHIR resource to an Avro {@link IndexedRecord}.
    *
    * @param resource the FHIR resource
-   * @return the row
+   * @return the record.
    */
   public IndexedRecord resourceToAvro(IBaseResource resource) {
 
     return (IndexedRecord) hapiToAvroConverter.fromHapi(resource);
   }
 
+  /**
+   * Converts a given Avro {@link IndexedRecord} to a FHIR resource.
+   *
+   * @param record the record
+   * @return the FHIR resource.
+   */
   public IBaseResource avroToResource(IndexedRecord record) {
 
     return (IBaseResource) avroToHapiConverter.toHapi(record);
@@ -180,7 +187,7 @@ public class AvroConverter {
   /**
    * Returns the Avro schema equivalent for the FHIR resource.
    *
-   * @return the Spark schema
+   * @return the Avro schema
    */
   public Schema getSchema() {
 

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -52,7 +52,7 @@ public class GenerateSchemas {
     }
 
     Map<String, List<String>> resourceTypeUrls = Arrays.stream(args)
-        .skip(2)
+        .skip(1)
         .collect(Collectors.toMap(Function.identity(), item -> Collections.emptyList()));
 
     List<Schema> schemas = AvroConverter.generateSchemas(FhirContexts.forStu3(), resourceTypeUrls);

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -6,7 +6,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 
@@ -47,7 +51,9 @@ public class GenerateSchemas {
       return 1;
     }
 
-    List<String> resourceTypeUrls = Arrays.asList(args).subList(1, args.length);
+    Map<String, List<String>> resourceTypeUrls = Arrays.stream(args)
+        .skip(2)
+        .collect(Collectors.toMap(Function.identity(), item -> Collections.emptyList()));
 
     List<Schema> schemas = AvroConverter.generateSchemas(FhirContexts.forStu3(), resourceTypeUrls);
 

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
@@ -4,15 +4,19 @@ import com.cerner.bunsen.FhirContexts;
 import com.cerner.bunsen.avro.AvroConverter;
 import com.cerner.bunsen.stu3.TestData;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javafx.beans.binding.ObjectBinding;
 import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalTypes;
@@ -20,15 +24,19 @@ import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.compiler.specific.SpecificCompiler;
+import org.apache.avro.generic.GenericData.Array;
 import org.apache.avro.generic.GenericData.Record;
 import org.hl7.fhir.dstu3.hapi.ctx.IValidationSupport;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IntegerType;
 import org.hl7.fhir.dstu3.model.Medication;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Provenance;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.hl7.fhir.dstu3.model.StructureDefinition.StructureDefinitionKind;
@@ -57,11 +65,23 @@ public class AvroConverterTest {
 
   private static Condition testConditionDecoded;
 
-  private static final Medication testMedication = TestData.newMedication();
+  private static final Medication testMedicationOne = TestData.newMedication("test-medication-1");
 
-  private static Record avroMedication;
+  private static final Medication testMedicationOTwo = TestData.newMedication("test-medication-2");
 
   private static Medication testMedicationDecoded;
+
+  private static final Provenance testProvenance = TestData.newProvenance();
+
+  private static final MedicationRequest testMedicationRequest =
+      (MedicationRequest) TestData.newMedicationRequest()
+          .addContained(testMedicationOne)
+          .addContained(testProvenance)
+          .addContained(testMedicationOTwo);
+
+  private static Record avroMedicationRequest;
+
+  private static MedicationRequest testMedicationRequestDecoded;
 
   /**
    * Initialize test data.
@@ -93,9 +113,19 @@ public class AvroConverterTest {
     AvroConverter medicationConverter = AvroConverter.forResource(FhirContexts.forStu3(),
         TestData.US_CORE_MEDICATION);
 
-    avroMedication = (Record) medicationConverter.resourceToAvro(testMedication);
+    Record avroMedication = (Record) medicationConverter.resourceToAvro(testMedicationOne);
 
     testMedicationDecoded = (Medication) medicationConverter.avroToResource(avroMedication);
+
+    AvroConverter medicationRequestConverter = AvroConverter.forResource(FhirContexts.forStu3(),
+        TestData.US_CORE_MEDICATION_REQUEST,
+        Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE));
+
+    avroMedicationRequest = (Record) medicationRequestConverter
+        .resourceToAvro(testMedicationRequest);
+
+    testMedicationRequestDecoded = (MedicationRequest) medicationRequestConverter
+        .avroToResource(avroMedicationRequest);
   }
 
   @Test
@@ -134,10 +164,10 @@ public class AvroConverterTest {
   @Test
   public void testIdenticalChoicesTypes() {
 
-    Assert.assertTrue(testMedication.getIngredientFirstRep()
+    Assert.assertTrue(testMedicationOne.getIngredientFirstRep()
         .equalsDeep(testMedicationDecoded.getIngredientFirstRep()));
 
-    Assert.assertTrue(testMedication.getPackage().getContentFirstRep()
+    Assert.assertTrue(testMedicationOne.getPackage().getContentFirstRep()
         .equalsDeep(testMedicationDecoded.getPackage().getContentFirstRep()));
   }
 
@@ -297,11 +327,56 @@ public class AvroConverterTest {
   }
 
   @Test
+  public void testContainedResources() throws FHIRException {
+
+    Medication testMedicationOne = (Medication) testMedicationRequest.getContained().get(0);
+
+    String testMedicationOneId = testMedicationOne.getId();
+
+    CodeableConcept testMedicationIngredientItem = testMedicationOne.getIngredientFirstRep()
+        .getItemCodeableConcept();
+
+    Medication decodedMedicationOne = (Medication) testMedicationRequestDecoded.getContained()
+        .get(0);
+
+    String decodedMedicationOneId = decodedMedicationOne.getId();
+
+    CodeableConcept decodedMedicationOneIngredientItem = decodedMedicationOne
+        .getIngredientFirstRep()
+        .getItemCodeableConcept();
+
+    Assert.assertEquals(testMedicationOneId, decodedMedicationOneId);
+    Assert.assertTrue(decodedMedicationOneIngredientItem.equalsDeep(testMedicationIngredientItem));
+
+    Provenance testProvenance = (Provenance) testMedicationRequest.getContained().get(1);
+
+    String testProvenanceId = testProvenance.getId();
+
+    Provenance decodedProvenance = (Provenance) testMedicationRequestDecoded.getContained().get(1);
+
+    String decodedProvenanceId = decodedProvenance.getId();
+
+    Assert.assertEquals(testProvenanceId, decodedProvenanceId);
+
+    Medication testMedicationTwo = (Medication) testMedicationRequest.getContained().get(2);
+
+    String testMedicationTwoId = testMedicationTwo.getId();
+
+    Medication decodedMedicationTwo = (Medication) testMedicationRequestDecoded.getContained()
+        .get(2);
+
+    String decodedMedicationTwoId = decodedMedicationTwo.getId();
+
+    Assert.assertEquals(testMedicationTwoId, decodedMedicationTwoId);
+  }
+
+  @Test
   public void testCompile() throws IOException {
 
     List<Schema> schemas = AvroConverter.generateSchemas(FhirContexts.forStu3(),
-        ImmutableList.of(TestData.US_CORE_PATIENT,
-            TestData.VALUE_SET));
+        ImmutableMap.of(TestData.US_CORE_PATIENT, Collections.emptyList(),
+            TestData.VALUE_SET, Collections.emptyList(),
+            TestData.US_CORE_MEDICATION_REQUEST, ImmutableList.of(TestData.US_CORE_MEDICATION)));
 
     // Wrap the schemas in a protocol to simplify the invocation of the compiler.
     Protocol protocol = new Protocol("fhir-test",
@@ -339,5 +414,9 @@ public class AvroConverterTest {
 
     // Choice types include each choice that could be used.
     Assert.assertTrue(javaFiles.contains("com/cerner/bunsen/stu3/avro/ChoiceBooleanInteger.java"));
+
+    // Contained types created.
+    Assert.assertTrue(javaFiles.contains(
+        "com/cerner/bunsen/stu3/avro/MedicationRequestContained.java"));
   }
 }

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
@@ -1,14 +1,11 @@
 package com.cerner.bunsen.avro;
 
 import com.cerner.bunsen.FhirContexts;
-import com.cerner.bunsen.avro.AvroConverter;
 import com.cerner.bunsen.stu3.TestData;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -16,17 +13,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javafx.beans.binding.ObjectBinding;
-import org.apache.avro.Conversion;
-import org.apache.avro.Conversions;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
-import org.apache.avro.Schema.Type;
 import org.apache.avro.compiler.specific.SpecificCompiler;
-import org.apache.avro.generic.GenericData.Array;
 import org.apache.avro.generic.GenericData.Record;
-import org.hl7.fhir.dstu3.hapi.ctx.IValidationSupport;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
@@ -38,8 +28,6 @@ import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Provenance;
 import org.hl7.fhir.dstu3.model.Quantity;
-import org.hl7.fhir.dstu3.model.StructureDefinition;
-import org.hl7.fhir.dstu3.model.StructureDefinition.StructureDefinitionKind;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -330,17 +318,13 @@ public class AvroConverterTest {
   public void testContainedResources() throws FHIRException {
 
     Medication testMedicationOne = (Medication) testMedicationRequest.getContained().get(0);
-
     String testMedicationOneId = testMedicationOne.getId();
-
     CodeableConcept testMedicationIngredientItem = testMedicationOne.getIngredientFirstRep()
         .getItemCodeableConcept();
 
     Medication decodedMedicationOne = (Medication) testMedicationRequestDecoded.getContained()
         .get(0);
-
     String decodedMedicationOneId = decodedMedicationOne.getId();
-
     CodeableConcept decodedMedicationOneIngredientItem = decodedMedicationOne
         .getIngredientFirstRep()
         .getItemCodeableConcept();
@@ -349,22 +333,18 @@ public class AvroConverterTest {
     Assert.assertTrue(decodedMedicationOneIngredientItem.equalsDeep(testMedicationIngredientItem));
 
     Provenance testProvenance = (Provenance) testMedicationRequest.getContained().get(1);
-
     String testProvenanceId = testProvenance.getId();
 
     Provenance decodedProvenance = (Provenance) testMedicationRequestDecoded.getContained().get(1);
-
     String decodedProvenanceId = decodedProvenance.getId();
 
     Assert.assertEquals(testProvenanceId, decodedProvenanceId);
 
     Medication testMedicationTwo = (Medication) testMedicationRequest.getContained().get(2);
-
     String testMedicationTwoId = testMedicationTwo.getId();
 
     Medication decodedMedicationTwo = (Medication) testMedicationRequestDecoded.getContained()
         .get(2);
-
     String decodedMedicationTwoId = decodedMedicationTwo.getId();
 
     Assert.assertEquals(testMedicationTwoId, decodedMedicationTwoId);
@@ -417,6 +397,6 @@ public class AvroConverterTest {
 
     // Contained types created.
     Assert.assertTrue(javaFiles.contains(
-        "com/cerner/bunsen/stu3/avro/MedicationRequestContained.java"));
+        "com/cerner/bunsen/stu3/avro/us/core/MedicationRequestContained.java"));
   }
 }

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
@@ -55,7 +55,7 @@ public class AvroConverterTest {
 
   private static final Medication testMedicationOne = TestData.newMedication("test-medication-1");
 
-  private static final Medication testMedicationOTwo = TestData.newMedication("test-medication-2");
+  private static final Medication testMedicationTwo = TestData.newMedication("test-medication-2");
 
   private static Medication testMedicationDecoded;
 
@@ -65,7 +65,7 @@ public class AvroConverterTest {
       (MedicationRequest) TestData.newMedicationRequest()
           .addContained(testMedicationOne)
           .addContained(testProvenance)
-          .addContained(testMedicationOTwo);
+          .addContained(testMedicationTwo);
 
   private static Record avroMedicationRequest;
 

--- a/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -39,11 +39,13 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
       if (!parent.getContentReference().startsWith("#")) {
 
-        throw new IllegalStateException("Non-local references are not supported");
+        throw new IllegalStateException("Non-local references are not yet supported");
       }
 
+      // Remove the leading hash (#) to get the referenced type.
       String referencedType = parent.getContentReference().substring(1);
 
+      // Find the actual type to use.
       parent = definitions.stream()
           .filter(definition -> definition.getPath().equals(referencedType))
           .findFirst()
@@ -293,7 +295,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
         }
       }
 
-      StructureField<T> field = new StructureField<T>(elementName,
+      StructureField<T> field = new StructureField<>(elementName,
           elementName,
           null,
           true,

--- a/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
+++ b/bunsen-core-stu3/src/main/java/com/cerner/bunsen/definitions/stu3/Stu3StructureDefinitions.java
@@ -10,7 +10,6 @@ import com.cerner.bunsen.definitions.StructureField;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-
 import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,72 +27,88 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
   private static final FhirConversionSupport CONVERSION_SUPPORT = new Stu3FhirConversionSupport();
 
-  /**
-   * Returns the immediate children of the given element from the list of all defined
-   * elements in the structure definition.
-   *
-   * @param parent the element to get the children for
-   * @param definitions the full list of element definitions
-   * @return the list of elements that are children of the given element
-   */
+  public Stu3StructureDefinitions(FhirContext context) {
+
+    super(context);
+  }
+
   private List<ElementDefinition> getChildren(ElementDefinition parent,
       List<ElementDefinition> definitions) {
 
     if (parent.getContentReference() != null) {
 
       if (!parent.getContentReference().startsWith("#")) {
-        throw new IllegalStateException("Non-local references are not yet supported");
+
+        throw new IllegalStateException("Non-local references are not supported");
       }
 
-      // Remove the leading hash (#) to get the referenced type.
       String referencedType = parent.getContentReference().substring(1);
 
-      // Find the actual type to use.
       parent = definitions.stream()
           .filter(definition -> definition.getPath().equals(referencedType))
           .findFirst()
-          .get();
+          .orElseThrow(() -> new IllegalArgumentException("Expected a reference type"));
     }
 
     String startsWith = parent.getId() + ".";
 
-    // Get nodes
-    return definitions.stream().filter(definition ->
-        definition.getId().startsWith(startsWith)
+    return definitions.stream()
+        .filter(definition -> definition.getId().startsWith(startsWith)
             && definition.getId().indexOf('.', startsWith.length()) < 0)
         .collect(Collectors.toList());
   }
 
-  public Stu3StructureDefinitions(FhirContext context) {
-
-    super(context);
-  }
-
   private String elementName(ElementDefinition element) {
 
-    String suffix = element.getPath().substring(element.getPath().lastIndexOf(".") + 1);
+    String suffix = element.getPath().substring(element.getPath().lastIndexOf('.') + 1);
 
-    // Remove the [x] suffix used by choise types, if applicable.
     return suffix.endsWith("[x]")
         ? suffix.substring(0, suffix.length() - 3)
         : suffix;
   }
 
-  /**
-   * Returns the StructureDefinition for the given element if it is an
-   * externally defined datatype. Returns null otherwise.
-   */
   private StructureDefinition getDefinition(ElementDefinition element) {
 
-    // Elements that don't specify a type or are backbone elements defined
-    // within the parent structure do not have a separate structure definition.
     return element.getTypeFirstRep() == null
         || element.getTypeFirstRep().getCode() == null
         || element.getTypeFirstRep().getCode().equals("BackboneElement")
         || element.getTypeFirstRep().getCode().equals("Element")
         ? null
-        : (StructureDefinition) validationSupport.fetchStructureDefinition(
-            context, element.getTypeFirstRep().getCode());
+        : (StructureDefinition) validationSupport.fetchStructureDefinition(context,
+            element.getTypeFirstRep().getCode());
+  }
+
+  private <T> List<StructureField<T>> singleField(String elementName, T result) {
+
+    return Collections.singletonList(StructureField.property(elementName, result));
+  }
+
+  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
+      StructureDefinition structureDefinition,
+      Deque<QualifiedPath> stack) {
+
+    ElementDefinition definitionRootElement = structureDefinition.getSnapshot().getElement().get(0);
+
+    return shouldTerminateRecursive(visitor, structureDefinition, definitionRootElement, stack);
+  }
+
+  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
+      StructureDefinition rootDefinition,
+      ElementDefinition elementDefinition, Deque<QualifiedPath> stack) {
+
+
+    return shouldTerminateRecursive(visitor,
+        new QualifiedPath(rootDefinition.getUrl(), elementDefinition.getPath()),
+        stack);
+  }
+
+  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
+      QualifiedPath newPath,
+      Deque<QualifiedPath> stack) {
+
+    int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
+
+    return stack.stream().filter(path -> path.equals(newPath)).count() > maxDepth;
   }
 
   private <T> List<StructureField<T>> extensionElementToFields(DefinitionVisitor<T> visitor,
@@ -219,10 +234,6 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
     }
   }
 
-  private <T> List<StructureField<T>> singleField(String elementName, T result) {
-
-    return Collections.singletonList(StructureField.property(elementName, result));
-  }
 
   /**
    * Returns the fields for the given element. The returned stream can be empty
@@ -261,7 +272,7 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
       // Use a linked hash map to preserve the order of the fields
       // for iteration.
-      Map<String,T> choiceTypes = new LinkedHashMap<>();
+      Map<String, T> choiceTypes = new LinkedHashMap<>();
 
       for (TypeRefComponent typeRef: element.getType()) {
 
@@ -279,7 +290,6 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
           T child = transform(visitor, element, structureDefinition, new ArrayDeque<>());
 
           choiceTypes.put(typeRef.getCode(), child);
-
         }
       }
 
@@ -333,7 +343,6 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
         // Wrap the item in the corresponding multi-valued type.
         return singleField(elementName,
             visitor.visitMultiValued(elementName, composite.get(0).result()));
-
       }
 
     } else if (getDefinition(element) != null) {
@@ -367,9 +376,6 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
     }
   }
 
-  /**
-   * Transform methods of child elements.
-   */
   private <T> List<StructureField<T>> transformChildren(DefinitionVisitor<T> visitor,
       StructureDefinition rootDefinition,
       List<ElementDefinition> definitions,
@@ -402,32 +408,47 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
     }
   }
 
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      StructureDefinition structureDefinition,
-      Deque<QualifiedPath> stack) {
-
-    ElementDefinition definitionRootElement = structureDefinition.getSnapshot().getElement().get(0);
-
-    return shouldTerminateRecursive(visitor, structureDefinition, definitionRootElement, stack);
-  }
-
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
+  private <T> StructureField<T> transformContained(DefinitionVisitor<T> visitor,
       StructureDefinition rootDefinition,
-      ElementDefinition elementDefinition, Deque<QualifiedPath> stack) {
+      List<StructureDefinition> containedDefinitions,
+      Deque<QualifiedPath> stack,
+      ElementDefinition element) {
 
+    Map<String, StructureField<T>> containedElements = new LinkedHashMap<>();
 
-    return shouldTerminateRecursive(visitor,
-        new QualifiedPath(rootDefinition.getUrl(), elementDefinition.getPath()),
-        stack);
-  }
+    for (StructureDefinition containedDefinition: containedDefinitions) {
 
-  private boolean shouldTerminateRecursive(DefinitionVisitor visitor,
-      QualifiedPath newPath,
-      Deque<QualifiedPath> stack) {
+      ElementDefinition containedRootElement = containedDefinition.getSnapshot()
+          .getElementFirstRep();
 
-    int maxDepth = visitor.getMaxDepth(newPath.getParentTypeUrl(), newPath.getElementPath());
+      List<ElementDefinition> childDefinitions = containedDefinition.getSnapshot().getElement();
 
-    return stack.stream().filter(path -> path.equals(newPath)).count() > maxDepth;
+      stack.push(new QualifiedPath(containedDefinition.getUrl(), containedRootElement.getPath()));
+
+      List<StructureField<T>> childElements = transformChildren(visitor,
+          containedDefinition,
+          childDefinitions,
+          stack,
+          containedRootElement);
+
+      stack.pop();
+
+      String rootName = elementName(containedRootElement);
+
+      T result = visitor.visitComposite(rootName,
+          containedRootElement.getPath(),
+          rootName,
+          containedDefinition.getUrl(),
+          childElements);
+
+      containedElements.put(rootName, StructureField.property(rootName, result));
+    }
+
+    T result = visitor.visitContained(element.getPath() + ".contained",
+        rootDefinition.getUrl(),
+        containedElements);
+
+    return StructureField.property("contained", result);
   }
 
   @Override
@@ -455,9 +476,41 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
    *
    * @return The schema as a Spark StructType
    */
-  public <T> T transform(DefinitionVisitor<T> visitor,  StructureDefinition definition) {
+  public <T> T transform(DefinitionVisitor<T> visitor, StructureDefinition definition) {
 
     return transform(visitor, null, definition, new ArrayDeque<>());
+  }
+
+  @Override
+  public <T> T transform(DefinitionVisitor<T> visitor,
+      String resourceTypeUrl,
+      List<String> containedResourceTypeUrls) {
+
+    StructureDefinition definition = (StructureDefinition) context.getValidationSupport()
+        .fetchStructureDefinition(context, resourceTypeUrl);
+
+    if (definition == null) {
+
+      throw new IllegalArgumentException("Unable to find definition for " + resourceTypeUrl);
+    }
+
+    List<StructureDefinition> containedDefinitions = containedResourceTypeUrls.stream()
+        .map(containedResourceTypeUrl -> {
+          StructureDefinition containedDefinition = (StructureDefinition) context
+              .getValidationSupport()
+              .fetchStructureDefinition(context, containedResourceTypeUrl);
+
+          if (containedDefinition == null) {
+
+            throw new IllegalArgumentException("Unable to find definition for "
+                + containedResourceTypeUrl);
+          }
+
+          return containedDefinition;
+        })
+        .collect(Collectors.toList());
+
+    return transformRoot(visitor, definition, containedDefinitions, new ArrayDeque<>());
   }
 
   /**
@@ -516,13 +569,54 @@ public class Stu3StructureDefinitions extends StructureDefinitions {
 
       String rootName = elementName(root);
 
-      T result = visitor.visitComposite(rootName,
+      return visitor.visitComposite(rootName,
           rootName,
           rootName,
           definition.getUrl(),
           childElements);
-
-      return result;
     }
+  }
+
+  private <T> T transformRoot(DefinitionVisitor<T> visitor,
+      StructureDefinition definition,
+      List<StructureDefinition> containedDefinitions,
+      Deque<QualifiedPath> stack) {
+
+    ElementDefinition definitionRootElement = definition.getSnapshot().getElementFirstRep();
+
+    List<ElementDefinition> definitions = definition.getSnapshot().getElement();
+
+    ElementDefinition root = definitions.get(0);
+
+    stack.push(new QualifiedPath(definition.getUrl(), definitionRootElement.getPath()));
+
+    List<StructureField<T>> childElements = transformChildren(visitor,
+        definition,
+        definitions,
+        stack,
+        root);
+
+    // If there are contained definitions, create a Resource Container StructureField
+    if (containedDefinitions.size() > 0) {
+
+      StructureField<T> containedElement = transformContained(visitor,
+          definition,
+          containedDefinitions,
+          stack,
+          root);
+
+      // Replace default StructureField with constructed Resource Container StructureField
+      childElements.set(5, containedElement);
+    }
+
+    stack.pop();
+
+    String rootName = elementName(root);
+
+    return visitor.visitComposite(rootName,
+        rootName,
+        rootName,
+        definition.getUrl(),
+        childElements);
   }
 }

--- a/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
+++ b/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
@@ -23,6 +23,7 @@ import org.hl7.fhir.dstu3.model.Narrative;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationComponentComponent;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Provenance;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.StringType;
@@ -56,6 +57,9 @@ public class TestData {
 
   public static final String US_CORE_MEDICATION_REQUEST =
       "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest";
+
+  public static final String PROVENANCE =
+      "http://hl7.org/fhir/StructureDefinition/Provenance";
 
   public static final String VALUE_SET =
       "http://hl7.org/fhir/StructureDefinition/ValueSet";
@@ -210,11 +214,11 @@ public class TestData {
    *
    * @return a FHIR Medication for testing.
    */
-  public static Medication newMedication() {
+  public static Medication newMedication(String id) {
 
     Medication medication = new Medication();
 
-    medication.setId("test-medication");
+    medication.setId(id);
 
     CodeableConcept itemCodeableConcept = new CodeableConcept();
     itemCodeableConcept.addCoding()
@@ -272,6 +276,20 @@ public class TestData {
         .setSubstitution(new MedicationRequestSubstitutionComponent().setAllowed(true));
 
     return medicationRequest;
+  }
+
+  /**
+   * Returns a new Provenance for testing.
+   *
+   * @return a FHIR Provenance for testing.
+   */
+  public static Provenance newProvenance() {
+
+    Provenance provenance = new Provenance();
+
+    provenance.setId("test-provenance");
+
+    return provenance;
   }
 
 }

--- a/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
+++ b/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
@@ -1,6 +1,6 @@
 package com.cerner.bunsen.stu3;
 
-import java.util.Arrays;
+import com.google.common.collect.ImmutableList;
 import org.hl7.fhir.dstu3.model.Address;
 import org.hl7.fhir.dstu3.model.CodeType;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -269,7 +269,7 @@ public class TestData {
     medicationRequest
         .setSubject(new Reference("Patient/12345").setDisplay("Here is a display for you."));
 
-    medicationRequest.setDosageInstruction(Arrays.asList(
+    medicationRequest.setDosageInstruction(ImmutableList.of(
         new Dosage().setTiming(new Timing().setRepeat(new TimingRepeatComponent().setCount(10)))));
 
     medicationRequest

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitor.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitor.java
@@ -17,7 +17,7 @@ public interface DefinitionVisitor<T> {
    * @param primitiveType the FHIR type of the primitive.
    * @return the visitor result.
    */
-  public T visitPrimitive(String elementName,
+  T visitPrimitive(String elementName,
       String primitiveType);
 
   /**
@@ -30,7 +30,7 @@ public interface DefinitionVisitor<T> {
    * @param children the composite type's children.
    * @return the visitor result.
    */
-  public T visitComposite(String elementName,
+  T visitComposite(String elementName,
       String elementPath,
       String baseType,
       String elementTypeUrl,
@@ -44,7 +44,7 @@ public interface DefinitionVisitor<T> {
    * @param contained the map of types to their contained elements.
    * @return the visitor result.
    */
-  public T visitContained(String elementPath,
+  T visitContained(String elementPath,
       String baseType,
       Map<String, StructureField<T>> contained);
 
@@ -56,7 +56,7 @@ public interface DefinitionVisitor<T> {
    * @param children the child fields of the reference
    * @return the visitor result.
    */
-  public T visitReference(String elementName,
+  T visitReference(String elementName,
       List<String> referenceTypes,
       List<StructureField<T>> children);
 
@@ -68,7 +68,7 @@ public interface DefinitionVisitor<T> {
    * @param children the children of the extension
    * @return the visitor result.
    */
-  public T visitParentExtension(String elementName,
+  T visitParentExtension(String elementName,
       String extensionUrl,
       List<StructureField<T>> children);
 
@@ -80,7 +80,7 @@ public interface DefinitionVisitor<T> {
    * @param element the children of the extension.
    * @return the visitor result.
    */
-  public T visitLeafExtension(String elementName,
+  T visitLeafExtension(String elementName,
       String extensionUrl,
       T element);
 
@@ -91,7 +91,7 @@ public interface DefinitionVisitor<T> {
    * @param arrayElement the visitor result for a single element of the array.
    * @return the visitor result.
    */
-  public T visitMultiValued(String elementName,
+  T visitMultiValued(String elementName,
       T arrayElement);
 
   /**
@@ -101,7 +101,7 @@ public interface DefinitionVisitor<T> {
    * @param fhirToChoiceTypes a map of the choice type with the returned children.
    * @return the visitor result.
    */
-  public T visitChoice(String elementName,
+  T visitChoice(String elementName,
       Map<String,T> fhirToChoiceTypes);
 
   /**
@@ -111,5 +111,5 @@ public interface DefinitionVisitor<T> {
    * @param path the path to the element that is recursive
    * @return the depth the visitor should recur to.
    */
-  public int getMaxDepth(String elementTypeUrl, String path);
+  int getMaxDepth(String elementTypeUrl, String path);
 }

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitor.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitor.java
@@ -37,6 +37,18 @@ public interface DefinitionVisitor<T> {
       List<StructureField<T>> children);
 
   /**
+   * Visits a container type.
+   *
+   * @param elementPath the FHIR path to the element.
+   * @param baseType the type of the container type.
+   * @param contained the map of types to their contained elements.
+   * @return the visitor result.
+   */
+  public T visitContained(String elementPath,
+      String baseType,
+      Map<String, StructureField<T>> contained);
+
+  /**
    * Visits a reference type.
    *
    * @param elementName the element to visit.

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiChoiceConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiChoiceConverter.java
@@ -20,16 +20,7 @@ public abstract class HapiChoiceConverter<T> extends HapiConverter<T> {
 
   private final FhirConversionSupport fhirSupport;
 
-  protected HapiChoiceConverter(Map<String,HapiConverter<T>> choiceTypes,
-      T structType,
-      FhirConversionSupport fhirSupport) {
-
-    this.choiceTypes = choiceTypes;
-    this.structType = structType;
-    this.fhirSupport = fhirSupport;
-  }
-
-  private class ChoiceFieldSetter implements HapiFieldSetter {
+  private final class ChoiceFieldSetter implements HapiFieldSetter {
 
     private final Map<String,HapiFieldSetter> choiceFieldSetters;
 
@@ -62,6 +53,16 @@ public abstract class HapiChoiceConverter<T> extends HapiConverter<T> {
       }
     }
   }
+
+  protected HapiChoiceConverter(Map<String, HapiConverter<T>> choiceTypes,
+      T structType,
+      FhirConversionSupport fhirSupport) {
+
+    this.choiceTypes = choiceTypes;
+    this.structType = structType;
+    this.fhirSupport = fhirSupport;
+  }
+
 
   @Override
   public Object fromHapi(Object input) {

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiCompositeConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiCompositeConverter.java
@@ -37,23 +37,10 @@ public abstract class HapiCompositeConverter<T> extends HapiConverter<T> {
 
   protected abstract boolean isMultiValued(T schemaType);
 
-  protected HapiCompositeConverter(String elementType,
-      List<StructureField<HapiConverter<T>>> children,
-      T structType,
-      FhirConversionSupport fhirSupport,
-      String extensionUrl) {
-
-    this.elementType = elementType;
-    this.children = children;
-    this.structType = structType;
-    this.extensionUrl = extensionUrl;
-    this.fhirSupport = fhirSupport;
-  }
-
   /**
    * Field setter that does nothing for synthetic or unsupported field types.
    */
-  private static class NoOpFieldSetter implements HapiFieldSetter,
+  private static final class NoOpFieldSetter implements HapiFieldSetter,
       HapiObjectConverter {
 
     @Override
@@ -68,7 +55,7 @@ public abstract class HapiCompositeConverter<T> extends HapiConverter<T> {
 
   private static final HapiFieldSetter NOOP_FIELD_SETTER = new NoOpFieldSetter();
 
-  protected class CompositeFieldSetter implements HapiFieldSetter,
+  protected final class CompositeFieldSetter implements HapiFieldSetter,
       HapiObjectConverter {
 
     private final List<StructureField<HapiFieldSetter>> children;
@@ -147,8 +134,20 @@ public abstract class HapiCompositeConverter<T> extends HapiConverter<T> {
       } else {
         fieldToSet.getMutator().setValue(parentObject, fhirObject);
       }
-
     }
+  }
+
+  protected HapiCompositeConverter(String elementType,
+      List<StructureField<HapiConverter<T>>> children,
+      T structType,
+      FhirConversionSupport fhirSupport,
+      String extensionUrl) {
+
+    this.elementType = elementType;
+    this.children = children;
+    this.structType = structType;
+    this.extensionUrl = extensionUrl;
+    this.fhirSupport = fhirSupport;
   }
 
   @Override
@@ -341,9 +340,5 @@ public abstract class HapiCompositeConverter<T> extends HapiConverter<T> {
   @Override
   public String getElementType() {
     return elementType;
-  }
-
-  public List<StructureField<HapiConverter<T>>> getChildren() {
-    return children;
   }
 }

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiContainedConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiContainedConverter.java
@@ -1,0 +1,145 @@
+package com.cerner.bunsen.definitions;
+
+import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
+import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
+import com.cerner.bunsen.definitions.HapiCompositeConverter.CompositeFieldSetter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.hl7.fhir.dstu3.model.DomainResource;
+import org.hl7.fhir.instance.model.api.IBase;
+
+/**
+ * Partial converter implementation for contained structures. Contained converters are distinct
+ * from {@link HapiCompositeConverter} in that a Contained converter must translate between a static
+ * Record Container and the dynamically typed container field of FHIR resources.
+ *
+ * @param <T> the type of the schema produced by the converter.
+ */
+public abstract class HapiContainedConverter<T> extends HapiConverter<T> {
+
+  private final Map<String, StructureField<HapiConverter<T>>> contained;
+
+  protected final T structType;
+
+  /**
+   * Retrieves the contained elements from their container, associated with their type.
+   * @param container the Resource Container
+   * @return the {@link List} of {@link ContainerEntry}.
+   */
+  protected abstract List<ContainerEntry> getContained(Object container);
+
+  /**
+   * Constructs a statically typed Resource Container populated with all contained entries.
+   * @param contained the entries to be contained.
+   * @return the Resource Container.
+   */
+  protected abstract Object createContained(Object[] contained);
+
+  protected HapiContainedConverter(Map<String, StructureField<HapiConverter<T>>> contained,
+      T structType) {
+
+    this.contained = contained;
+    this.structType = structType;
+  }
+
+  /**
+   * Represents the association of a contained element to its type.
+   */
+  protected class ContainerEntry {
+
+    private final String elementType;
+    private final Object element;
+
+    public ContainerEntry(String elementType, Object element) {
+
+      this.elementType = elementType;
+      this.element = element;
+    }
+
+    public String getElementType() {
+
+      return elementType;
+    }
+
+    public Object getElement() {
+
+      return element;
+    }
+  }
+
+  private class ContainedFieldSetter implements HapiFieldSetter {
+
+    private final Map<String, CompositeFieldSetter> contained;
+
+    private ContainedFieldSetter(Map<String, CompositeFieldSetter> contained) {
+
+      this.contained = contained;
+    }
+
+    @Override
+    public void setField(IBase parentObject,
+        BaseRuntimeChildDefinition fieldToSet,
+        Object object) {
+
+      List<ContainerEntry> containedEntries = getContained(object);
+
+      for (ContainerEntry containedEntry: containedEntries) {
+
+        String containedElementType = containedEntry.getElementType();
+
+        IBase resource = contained.get(containedElementType).toHapi(containedEntry.getElement());
+
+        fieldToSet.getMutator().addValue(parentObject, resource);
+      }
+    }
+  }
+
+  @Override
+  public Object fromHapi(Object input) {
+
+    List containedList = (List) input;
+
+    Object[] values = new Object[containedList.size()];
+
+    for (int valueIndex = 0; valueIndex < containedList.size(); ++valueIndex) {
+
+      DomainResource composite = (DomainResource) containedList.get(valueIndex);
+
+      StructureField<HapiConverter<T>> schemaEntry = contained.get(composite.fhirType());
+
+      values[valueIndex] = schemaEntry.result().fromHapi(composite);
+    }
+
+    return createContained(values);
+  }
+
+  @Override
+  public HapiFieldSetter toHapiConverter(BaseRuntimeElementDefinition... elementDefinitions) {
+
+    Map<String, CompositeFieldSetter> fieldSetters = new LinkedHashMap<>();
+
+    for (Entry<String, StructureField<HapiConverter<T>>> containedConverter:
+        contained.entrySet()) {
+
+      for (BaseRuntimeElementDefinition elementDefinition: elementDefinitions) {
+
+        if (elementDefinition.getName().equals(containedConverter.getKey())) {
+
+          fieldSetters.put(containedConverter.getKey(),
+              (CompositeFieldSetter) containedConverter.getValue().result()
+                  .toHapiConverter(elementDefinition));
+        }
+      }
+    }
+
+    return new ContainedFieldSetter(fieldSetters);
+  }
+
+  @Override
+  public T getDataType() {
+
+    return structType;
+  }
+}

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureDefinitions.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.support.IContextValidationSupport;
 import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -61,6 +62,19 @@ public abstract class StructureDefinitions {
    */
   public abstract <T> T transform(DefinitionVisitor<T> visitor,
       String resourceTypeUrl);
+
+  /**
+   * Transforms a FHIR resource to a type defined by the visitor.
+   * @param visitor a visitor class to recursively transform the structure.
+   * @param resourceTypeUrl the URL defining the resource type or profile.
+   * @param containedResourceTypeUrls the URLs defining the resource types or profiles to be
+   *        contained to the given resource.
+   * @param <T> the return type of the visitor.
+   * @return the transformed result.
+   */
+  public abstract <T> T transform(DefinitionVisitor<T> visitor,
+      String resourceTypeUrl,
+      List<String> containedResourceTypeUrls);
 
   /**
    * Returns supporting functions to make FHIR conversion work independent of version.

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureField.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/StructureField.java
@@ -103,7 +103,7 @@ public class StructureField<T> {
    */
   public static <T> StructureField<T> property(String propertyName, T visitorResult) {
 
-    return new StructureField<T>(propertyName, propertyName, null, false, visitorResult);
+    return new StructureField<>(propertyName, propertyName, null, false, visitorResult);
   }
 
   /**
@@ -119,6 +119,6 @@ public class StructureField<T> {
       String extensionUrl,
       T visitorResult) {
 
-    return new StructureField<T>(null, fieldName, extensionUrl, false, visitorResult);
+    return new StructureField<>(null, fieldName, extensionUrl, false, visitorResult);
   }
 }

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/SparkRowConverter.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/SparkRowConverter.java
@@ -2,16 +2,13 @@ package com.cerner.bunsen.spark;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
-
 import com.cerner.bunsen.definitions.HapiConverter;
 import com.cerner.bunsen.definitions.HapiConverter.HapiObjectConverter;
 import com.cerner.bunsen.definitions.StructureDefinitions;
 import com.cerner.bunsen.spark.converters.DefinitionToSparkVisitor;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
@@ -176,7 +176,6 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
           if (resourceContainer.get(j) != null) {
 
             GenericRowWithSchema row = (GenericRowWithSchema) resourceContainer.get(j);
-
             String columnName = resourceContainer.schema().fields()[j].name();
 
             containedEntries.add(new ContainerEntry(columnName, row));
@@ -200,7 +199,6 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
             new GenericRowWithSchema[structTypeHashToIndex.size()];
 
         GenericRowWithSchema containedRow = (GenericRowWithSchema) contained[i];
-
         int containedEntryStructTypeHash = containedRow.schema().hashCode();
 
         containerFields[structTypeHashToIndex.get(containedEntryStructTypeHash)] = containedRow;
@@ -222,6 +220,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
       MultiValuedtoHapiConverter(BaseRuntimeElementDefinition elementDefinition,
           HapiObjectConverter rowToHapiConverter) {
+
         this.elementDefinition = elementDefinition;
         this.rowToHapiConverter = rowToHapiConverter;
       }

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
@@ -2,10 +2,11 @@ package com.cerner.bunsen.spark.converters;
 
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
-import com.cerner.bunsen.definitions.ChoiceConverter;
 import com.cerner.bunsen.definitions.DefinitionVisitor;
 import com.cerner.bunsen.definitions.FhirConversionSupport;
+import com.cerner.bunsen.definitions.HapiChoiceConverter;
 import com.cerner.bunsen.definitions.HapiCompositeConverter;
+import com.cerner.bunsen.definitions.HapiContainedConverter;
 import com.cerner.bunsen.definitions.HapiConverter;
 import com.cerner.bunsen.definitions.HapiConverter.HapiFieldSetter;
 import com.cerner.bunsen.definitions.HapiConverter.HapiObjectConverter;
@@ -15,6 +16,8 @@ import com.cerner.bunsen.definitions.StringConverter;
 import com.cerner.bunsen.definitions.StructureField;
 import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,6 +33,7 @@ import org.apache.spark.sql.types.StructType;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import scala.collection.JavaConversions;
+import scala.collection.mutable.WrappedArray;
 
 /**
  * A visitor implementation to travers a FHIR resource definition and produce
@@ -45,9 +49,9 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
   private static final DataType decimalType = DataTypes.createDecimalType(12, 4);
 
-  private static class ChoiceToSparkConverter extends ChoiceConverter<DataType> {
+  private static class HapiChoiceToSparkConverter extends HapiChoiceConverter<DataType> {
 
-    ChoiceToSparkConverter(Map<String,HapiConverter<DataType>> choiceTypes,
+    HapiChoiceToSparkConverter(Map<String,HapiConverter<DataType>> choiceTypes,
         StructType structType,
         FhirConversionSupport fhirSupport) {
 
@@ -74,9 +78,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
     @Override
     public void setField(IBase parentObject, BaseRuntimeChildDefinition fieldToSet,
-        Object sparkObject) {
-
-    }
+        Object sparkObject) {}
 
     @Override
     public IBase toHapi(Object input) {
@@ -88,16 +90,16 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
   private static final HapiFieldSetter NOOP_FIELD_SETTER = new NoOpFieldSetter();
 
 
-  private static class CompositeToSparkConverter extends HapiCompositeConverter<DataType> {
+  private static class HapiCompositeToSparkConverter extends HapiCompositeConverter<DataType> {
 
-    CompositeToSparkConverter(String elementType,
+    HapiCompositeToSparkConverter(String elementType,
         List<StructureField<HapiConverter<DataType>>> children,
         StructType structType,
         FhirConversionSupport fhirSupport) {
       this(elementType, children, structType, fhirSupport, null);
     }
 
-    CompositeToSparkConverter(String elementType,
+    HapiCompositeToSparkConverter(String elementType,
         List<StructureField<HapiConverter<DataType>>> children,
         StructType structType,
         FhirConversionSupport fhirSupport,
@@ -112,7 +114,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
       // The row being converted may have come from a different schema or profile
       // than what is being requested by the caller, so we must look up fields
       // by name.
-      String fieldName = ((StructType) this.structType).fields()[index].name();
+      String fieldName = ((StructType) getDataType()).apply(index).name();
 
       scala.Option fieldIndex = ((GenericRowWithSchema) composite)
               .schema()
@@ -127,12 +129,86 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
     @Override
     protected Object createComposite(Object[] children) {
-      return RowFactory.create(children);
+
+      return new GenericRowWithSchema(children, (StructType) getDataType());
     }
 
     @Override
     protected boolean isMultiValued(DataType schemaType) {
       return schemaType instanceof ArrayType;
+    }
+  }
+
+  private static class HapiContainedToSparkConverter extends HapiContainedConverter<DataType> {
+
+    private final Map<Integer, Integer> structTypeHashToIndex = new HashMap<>();
+
+    private final StructType containerType;
+
+    private HapiContainedToSparkConverter(
+        Map<String, StructureField<HapiConverter<DataType>>> contained,
+        DataType dataType) {
+
+      super(contained, dataType);
+
+      this.containerType = (StructType) ((ArrayType) dataType).elementType();
+
+      for (int i = 0; i < containerType.fields().length; i++) {
+
+        structTypeHashToIndex.put(containerType.apply(i).dataType().hashCode(), i);
+      }
+    }
+
+    @Override
+    protected List<ContainerEntry> getContained(Object container) {
+
+      WrappedArray containedArray = (WrappedArray) container;
+
+      List<ContainerEntry> containedEntries = new ArrayList<>();
+
+      for (int i = 0; i < containedArray.length(); i++) {
+
+        GenericRowWithSchema resourceContainer = (GenericRowWithSchema) containedArray.apply(i);
+
+        // The number of contained fields will be low, so this nested loop has low cost
+        for (int j = 0; j < resourceContainer.schema().fields().length; j++) {
+
+          if (resourceContainer.get(j) != null) {
+
+            GenericRowWithSchema row = (GenericRowWithSchema) resourceContainer.get(j);
+
+            String columnName = resourceContainer.schema().fields()[j].name();
+
+            containedEntries.add(new ContainerEntry(columnName, row));
+
+            break;
+          }
+        }
+      }
+
+      return containedEntries;
+    }
+
+    @Override
+    protected Object createContained(Object[] contained) {
+
+      GenericRowWithSchema[] containerArray = new GenericRowWithSchema[contained.length];
+
+      for (int i = 0; i < contained.length; i++) {
+
+        GenericRowWithSchema[] containerFields =
+            new GenericRowWithSchema[structTypeHashToIndex.size()];
+
+        GenericRowWithSchema containedRow = (GenericRowWithSchema) contained[i];
+
+        int containedEntryStructTypeHash = containedRow.schema().hashCode();
+
+        containerFields[structTypeHashToIndex.get(containedEntryStructTypeHash)] = containedRow;
+
+        containerArray[i] = new GenericRowWithSchema(containerFields, containerType);
+      }
+
+      return containerArray;
     }
   }
 
@@ -329,8 +405,26 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
             Metadata.empty()))
         .toArray(StructField[]::new);
 
-    return new CompositeToSparkConverter(baseType,
+    return new HapiCompositeToSparkConverter(baseType,
         children, new StructType(fields), fhirSupport);
+  }
+
+  @Override
+  public HapiConverter visitContained(String elementPath,
+      String elementTypeUrl,
+      Map<String, StructureField<HapiConverter<DataType>>> contained) {
+
+    StructField[] fields = contained.values()
+        .stream()
+        .map(containedEntry -> new StructField(containedEntry.fieldName(),
+              containedEntry.result().getDataType(),
+              true,
+              Metadata.empty()))
+        .toArray(StructField[]::new);
+
+    ArrayType container = new ArrayType(new StructType(fields), true);
+
+    return new HapiContainedToSparkConverter(contained, container);
   }
 
   @Override
@@ -362,7 +456,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
             Metadata.empty()))
         .toArray(StructField[]::new);
 
-    return new CompositeToSparkConverter(null,
+    return new HapiCompositeToSparkConverter(null,
         fieldsWithReferences,
         new StructType(fields), fhirSupport);
   }
@@ -385,7 +479,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
                 Metadata.empty()))
         .toArray(StructField[]::new);
 
-    return new CompositeToSparkConverter(null,
+    return new HapiCompositeToSparkConverter(null,
         children,
         new StructType(fields),
         fhirSupport,
@@ -397,7 +491,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
       String extensionUri,
       HapiConverter elementConverter) {
 
-    return new LeafExtensionConverter<DataType>(extensionUri, elementConverter);
+    return new LeafExtensionConverter<>(extensionUri, elementConverter);
   }
 
   @Override
@@ -409,7 +503,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
   @Override
   public HapiConverter<DataType> visitChoice(String elementName,
-      Map<String,HapiConverter<DataType>> choiceTypes) {
+      Map<String, HapiConverter<DataType>> choiceTypes) {
 
     StructField[] fields = choiceTypes.entrySet().stream()
         .map(entry -> {
@@ -426,7 +520,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
         })
         .toArray(StructField[]::new);
 
-    return new ChoiceToSparkConverter(choiceTypes,
+    return new HapiChoiceToSparkConverter(choiceTypes,
         new StructType(fields),
         fhirSupport);
   }

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
@@ -30,7 +30,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.collection.mutable.WrappedArray;
 
 public class SparkRowConverterTest {
 
@@ -335,17 +334,13 @@ public class SparkRowConverterTest {
   public void testContainedResources() throws FHIRException {
 
     Medication testMedicationOne = (Medication) testMedicationRequest.getContained().get(0);
-
     String testMedicationOneId = testMedicationOne.getId();
-
     CodeableConcept testMedicationIngredientItem = testMedicationOne.getIngredientFirstRep()
         .getItemCodeableConcept();
 
     Medication decodedMedicationOne = (Medication) testMedicationRequestDecoded.getContained()
         .get(0);
-
     String decodedMedicationOneId = decodedMedicationOne.getId();
-
     CodeableConcept decodedMedicationOneIngredientItem = decodedMedicationOne
         .getIngredientFirstRep()
         .getItemCodeableConcept();
@@ -354,22 +349,18 @@ public class SparkRowConverterTest {
     Assert.assertTrue(decodedMedicationOneIngredientItem.equalsDeep(testMedicationIngredientItem));
 
     Provenance testProvenance = (Provenance) testMedicationRequest.getContained().get(1);
-
     String testProvenanceId = testProvenance.getId();
 
     Provenance decodedProvenance = (Provenance) testMedicationRequestDecoded.getContained().get(1);
-
     String decodedProvenanceId = decodedProvenance.getId();
 
     Assert.assertEquals(testProvenanceId, decodedProvenanceId);
 
     Medication testMedicationTwo = (Medication) testMedicationRequest.getContained().get(2);
-
     String testMedicationTwoId = testMedicationTwo.getId();
 
     Medication decodedMedicationTwo = (Medication) testMedicationRequestDecoded.getContained()
         .get(2);
-
     String decodedMedicationTwoId = decodedMedicationTwo.getId();
 
     Assert.assertEquals(testMedicationTwoId, decodedMedicationTwoId);

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
@@ -5,6 +5,7 @@ import com.cerner.bunsen.FhirContexts;
 import com.cerner.bunsen.stu3.TestData;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -13,18 +14,23 @@ import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Medication;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Provenance;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import scala.collection.mutable.WrappedArray;
 
 public class SparkRowConverterTest {
 
@@ -48,8 +54,6 @@ public class SparkRowConverterTest {
 
   static FhirContext fhirContext;
 
-
-
   private static final String BASE_VALUESET = "ValueSet";
 
   private static final Patient testPatient = TestData.newPatient();
@@ -69,6 +73,22 @@ public class SparkRowConverterTest {
   private static Dataset<Row> testConditionDataset;
 
   private static Condition testConditionDecoded;
+
+  private static final Medication testMedicationOne = TestData.newMedication("test-medication-1");
+
+  private static final Medication testMedicationTwo = TestData.newMedication("test-medication-2");
+
+  private static final Provenance testProvenance =  TestData.newProvenance();
+
+  private static final MedicationRequest testMedicationRequest =
+      (MedicationRequest) TestData.newMedicationRequest()
+      .addContained(testMedicationOne)
+      .addContained(testProvenance)
+      .addContained(testMedicationTwo);
+
+  private static Dataset<Row> testMedicationRequestDataset;
+
+  private static MedicationRequest testMedicationRequestDecoded;
 
   /**
    * Loads resource definitions used for testing.
@@ -109,6 +129,19 @@ public class SparkRowConverterTest {
 
     testConditionDecoded =
         (Condition) conditionConverter.rowToResource(testConditionDataset.head());
+
+    SparkRowConverter medicationRequestConverter = SparkRowConverter.forResource(fhirContext,
+        TestData.US_CORE_MEDICATION_REQUEST,
+        Arrays.asList(TestData.US_CORE_MEDICATION, TestData.PROVENANCE));
+
+    Row testMedicationRequestRow = medicationRequestConverter.resourceToRow(testMedicationRequest);
+
+    testMedicationRequestDataset = spark.createDataFrame(
+        Collections.singletonList(testMedicationRequestRow),
+        medicationRequestConverter.getSchema());
+
+    testMedicationRequestDecoded = (MedicationRequest) medicationRequestConverter
+        .rowToResource(testMedicationRequestDataset.head());
   }
 
   @Test
@@ -298,6 +331,50 @@ public class SparkRowConverterTest {
     Assert.assertEquals(testText, textRow.get(0));
   }
 
+  @Test
+  public void testContainedResources() throws FHIRException {
+
+    Medication testMedicationOne = (Medication) testMedicationRequest.getContained().get(0);
+
+    String testMedicationOneId = testMedicationOne.getId();
+
+    CodeableConcept testMedicationIngredientItem = testMedicationOne.getIngredientFirstRep()
+        .getItemCodeableConcept();
+
+    Medication decodedMedicationOne = (Medication) testMedicationRequestDecoded.getContained()
+        .get(0);
+
+    String decodedMedicationOneId = decodedMedicationOne.getId();
+
+    CodeableConcept decodedMedicationOneIngredientItem = decodedMedicationOne
+        .getIngredientFirstRep()
+        .getItemCodeableConcept();
+
+    Assert.assertEquals(testMedicationOneId, decodedMedicationOneId);
+    Assert.assertTrue(decodedMedicationOneIngredientItem.equalsDeep(testMedicationIngredientItem));
+
+    Provenance testProvenance = (Provenance) testMedicationRequest.getContained().get(1);
+
+    String testProvenanceId = testProvenance.getId();
+
+    Provenance decodedProvenance = (Provenance) testMedicationRequestDecoded.getContained().get(1);
+
+    String decodedProvenanceId = decodedProvenance.getId();
+
+    Assert.assertEquals(testProvenanceId, decodedProvenanceId);
+
+    Medication testMedicationTwo = (Medication) testMedicationRequest.getContained().get(2);
+
+    String testMedicationTwoId = testMedicationTwo.getId();
+
+    Medication decodedMedicationTwo = (Medication) testMedicationRequestDecoded.getContained()
+        .get(2);
+
+    String decodedMedicationTwoId = decodedMedicationTwo.getId();
+
+    Assert.assertEquals(testMedicationTwoId, decodedMedicationTwoId);
+  }
+
   /**
    * Recursively walks the schema to ensure there are no struct fields that are empty.
    */
@@ -309,7 +386,6 @@ public class SparkRowConverterTest {
 
     for (StructField field: schema.fields()) {
 
-
       if (field.dataType() instanceof StructType) {
 
         checkNoEmptyStructs((StructType) field.dataType(), field.name());
@@ -320,7 +396,10 @@ public class SparkRowConverterTest {
 
         if (arrayType.elementType() instanceof StructType) {
 
-          checkNoEmptyStructs((StructType) arrayType.elementType(), field.name());
+          if (!field.name().equals("contained")) {
+
+            checkNoEmptyStructs((StructType) arrayType.elementType(), field.name());
+          }
         }
       }
     }
@@ -344,7 +423,6 @@ public class SparkRowConverterTest {
 
     checkNoEmptyStructs(schema, null);
   }
-
 
   @Test
   public void testDecodeWithDifferentProfile() {


### PR DESCRIPTION
Closes #62, adds support for Contained Resources.

**How**: Resources that are expected to be contained must be statically declared during creation of a `HapiConverter`. These Resources are then parsed along with their parent in such a way that the elements of a `DomainResource.contained` field can be transformed into a statically-typed list of Resource Container, a structure type having each Contained resource included as a field bearing the resource name. This Resource Container can then be converted back to a FHIR Resource's contained list.

**Note**: also fixes a bug with ChoiceTypes having references clashing with others of the same structure, but different possible referents. 