### PR TITLE
[0.5.0-dev] issue-74: fix for missing nested fields in Spark row schema

### DIFF
--- a/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
+++ b/bunsen-core-stu3/src/test/java/com/cerner/bunsen/stu3/TestData.java
@@ -22,6 +22,7 @@ import org.hl7.fhir.dstu3.model.MedicationRequest.MedicationRequestSubstitutionC
 import org.hl7.fhir.dstu3.model.Narrative;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.Observation.ObservationComponentComponent;
+import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Provenance;
 import org.hl7.fhir.dstu3.model.Quantity;
@@ -171,10 +172,14 @@ public class TestData {
 
     patient.setBirthDateElement(new DateType("1945-01-02"));
 
-    Address address = patient.addAddress();
-
     patient.addGeneralPractitioner().setReference("Practitioner/12345");
 
+    Identifier practitionerIdentifier = new Identifier();
+    practitionerIdentifier.setId("P123456");
+    practitionerIdentifier.getAssigner().setReference("Organization/123456");
+    patient.getGeneralPractitionerFirstRep().setIdentifier(practitionerIdentifier);
+
+    Address address = patient.addAddress();
     address.addLine("123 Fake Street");
     address.setCity("Chicago");
     address.setState("IL");

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/DefinitionVisitorsUtil.java
@@ -1,0 +1,64 @@
+package com.cerner.bunsen.definitions;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Util class that provides helper methods for concrete visitors that implement {@link
+ * DefinitionVisitor} interface.
+ */
+public class DefinitionVisitorsUtil {
+
+  private static final Pattern STRUCTURE_URL_PATTERN =
+      Pattern.compile("http:\\/\\/hl7.org\\/fhir(\\/.*)?\\/StructureDefinition\\/([^\\/]*)$");
+
+
+  /**
+   * Helper method to convert a given element path that's delimited by period to a concatenated
+   * string in title case.
+   *
+   * @param elementPath the element path delimited by period to be converted
+   * @return a converted {@link String}
+   */
+  public static String recordNameFor(String elementPath) {
+
+    return Arrays.stream(elementPath.split("\\."))
+        .map(StringUtils::capitalize)
+        .reduce(String::concat)
+        .get();
+  }
+
+  /**
+   * Helper method that returns a fully qualified namespace for a given StructureDefinition url.
+   *
+   * @param basePackage the base package to be used as prefix in the returned namespace
+   * @param structureDefinitionUrl the StructureDefinition url
+   * @return a fully qualified namespace
+   */
+  public static String namespaceFor(String basePackage, String structureDefinitionUrl) {
+
+    Matcher matcher = STRUCTURE_URL_PATTERN.matcher(structureDefinitionUrl);
+
+    if (matcher.matches()) {
+
+      String profile = matcher.group(1);
+
+      if (profile != null && profile.length() > 0) {
+
+        String subPackage = profile.replaceAll("/", ".");
+
+        return basePackage + subPackage;
+
+      } else {
+        return basePackage;
+      }
+
+    } else {
+      throw new IllegalArgumentException(
+          "Unrecognized structure definition URL: " + structureDefinitionUrl);
+    }
+  }
+
+}


### PR DESCRIPTION
### Summary
Fixes [issue-74](https://github.com/cerner/bunsen/issues/74).

For Composite, Reference, Extension and Choice types the [DefinitionToAvroVisitor](https://github.com/cerner/bunsen/blob/0.5.0-dev/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java), the visitor that generates `Avro` schema caches corresponding converters in a [map](https://github.com/cerner/bunsen/blob/78806aadc69811ce62b5298b608161def0708f24/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java#L46) and avoids going into a recursion if the same structure is already generated and available in map.
 
In this PR, refactored and applied similar caching to [DefinitionToSparkVisitor](https://github.com/cerner/bunsen/blob/0.5.0-dev/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java), so that the `Spark` row schema is generated equivalent to the `Avro` schema. This also removes overhead of regenerating the same converters.