### PR TITLE
issue-80: adds support for null status

### DIFF
--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import com.cerner.bunsen.definitions.DefinitionVisitor;
 import com.cerner.bunsen.definitions.DefinitionVisitorsUtil;
+import com.cerner.bunsen.definitions.EnumConverter;
 import com.cerner.bunsen.definitions.FhirConversionSupport;
 import com.cerner.bunsen.definitions.HapiChoiceConverter;
 import com.cerner.bunsen.definitions.HapiCompositeConverter;
@@ -47,6 +48,9 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
   private static final HapiConverter STRING_CONVERTER =
       new StringConverter(Schema.create(Type.STRING));
 
+  private static final HapiConverter ENUM_CONVERTER =
+      new EnumConverter(Schema.create(Type.STRING));
+
   private static final HapiConverter DATE_CONVERTER =
       new StringConverter(Schema.create(Type.STRING));
 
@@ -80,7 +84,8 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
 
     private final Conversion<BigDecimal> conversion = new Conversions.DecimalConversion();
 
-    protected void toHapi(Object input, IPrimitiveType primitive) {
+    @Override
+    public void toHapi(Object input, IPrimitiveType primitive) {
 
       primitive.setValue(input);
     }
@@ -95,9 +100,6 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
       return DECIMAL_SCHEMA;
     }
   };
-
-  private static final HapiConverter ENUM_CONVERTER =
-      new StringConverter(Schema.create(Type.STRING));
 
   static final Map<String,HapiConverter> TYPE_TO_CONVERTER =
       ImmutableMap.<String,HapiConverter>builder()

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/AvroConverterTest.java
@@ -41,6 +41,13 @@ public class AvroConverterTest {
 
   private static Observation testObservationDecoded;
 
+  private static final Observation testObservationNullStatus = TestData.newObservation()
+      .setStatus(Observation.ObservationStatus.NULL);
+
+  private static Record avroObservationNullStatus;
+
+  private static Observation testObservationDecodedNullStatus;
+
   private static final Patient testPatient = TestData.newPatient();
 
   private static Record avroPatient;
@@ -90,6 +97,12 @@ public class AvroConverterTest {
     avroObservation = (Record) observationConverter.resourceToAvro(testObservation);
 
     testObservationDecoded = (Observation) observationConverter.avroToResource(avroObservation);
+
+    avroObservationNullStatus = (Record) observationConverter
+        .resourceToAvro(testObservationNullStatus);
+
+    testObservationDecodedNullStatus = (Observation) observationConverter
+        .avroToResource(avroObservationNullStatus);
 
     AvroConverter patientConverter = AvroConverter.forResource(FhirContexts.forStu3(),
         TestData.US_CORE_PATIENT);
@@ -195,6 +208,14 @@ public class AvroConverterTest {
 
     Assert.assertEquals(testObservation.getStatus(),
         testObservationDecoded.getStatus());
+  }
+
+  @Test
+  public void testBoundCodeNull() {
+
+    Assert.assertNull(avroObservationNullStatus.get("status"));
+
+    Assert.assertNull(testObservationDecodedNullStatus.getStatusElement().getValue());
   }
 
   @Test

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/EnumConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/EnumConverter.java
@@ -2,31 +2,28 @@ package com.cerner.bunsen.definitions;
 
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
-public class StringConverter<T> extends PrimitiveConverter<T> {
+public class EnumConverter<T> extends StringConverter<T> {
 
-  private final T dataType;
+  public EnumConverter(T dataType) {
 
-  public StringConverter(T dataType) {
-    super("String");
-    this.dataType = dataType;
+    super(dataType);
   }
 
   @Override
   public void toHapi(Object input, IPrimitiveType primitive) {
+
+    if ("?".equals(input)) {
+
+      input = null;
+    }
+
     primitive.setValueAsString((String) input);
   }
 
   protected Object fromHapi(IPrimitiveType primitive) {
-    return primitive.getValueAsString();
+
+    return "?".equals(primitive.getValueAsString())
+        ? null
+        : primitive.getValueAsString();
   }
-
-
-  @Override
-  public T getDataType() {
-
-    return dataType;
-  }
-
 }
-
-

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/HapiConverter.java
@@ -2,7 +2,6 @@ package com.cerner.bunsen.definitions;
 
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
-
 import org.hl7.fhir.instance.model.api.IBase;
 
 /**

--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
@@ -45,7 +45,12 @@ public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
     this.elementType = elementType;
   }
 
-  protected void toHapi(Object input, IPrimitiveType primitive) {
+  /**
+   * Helper method that will set the HAPI value.
+   * @param input the input object
+   * @param primitive the FHIR primitive to set
+   */
+  public void toHapi(Object input, IPrimitiveType primitive) {
     primitive.setValue(input);
   }
 
@@ -54,7 +59,7 @@ public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
   }
 
   @Override
-  public final Object fromHapi(Object input) {
+  public Object fromHapi(Object input) {
 
     return fromHapi((IPrimitiveType) input);
   }

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/converters/DefinitionToSparkVisitor.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import com.cerner.bunsen.definitions.DefinitionVisitor;
 import com.cerner.bunsen.definitions.DefinitionVisitorsUtil;
+import com.cerner.bunsen.definitions.EnumConverter;
 import com.cerner.bunsen.definitions.FhirConversionSupport;
 import com.cerner.bunsen.definitions.HapiChoiceConverter;
 import com.cerner.bunsen.definitions.HapiCompositeConverter;
@@ -309,7 +310,8 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
 
   private static HapiConverter DECIMAL_CONVERTER = new PrimitiveConverter("Decimal") {
 
-    protected void toHapi(Object input, IPrimitiveType primitive) {
+    @Override
+    public void toHapi(Object input, IPrimitiveType primitive) {
 
       primitive.setValueAsString(((BigDecimal) input).toPlainString());
     }
@@ -323,7 +325,7 @@ public class DefinitionToSparkVisitor implements DefinitionVisitor<HapiConverter
   private static final HapiConverter STRING_CONVERTER = new StringConverter(DataTypes.StringType);
 
 
-  private static final HapiConverter ENUM_CONVERTER = new StringConverter(DataTypes.StringType);
+  private static final HapiConverter ENUM_CONVERTER = new EnumConverter(DataTypes.StringType);
 
   /**
    * Converter that returns the relative value of a URI type.

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/SparkRowConverterTest.java
@@ -69,6 +69,13 @@ public class SparkRowConverterTest {
 
   private static Observation testObservationDecoded;
 
+  private static final Observation testObservationNullStatus = TestData.newObservation()
+      .setStatus(Observation.ObservationStatus.NULL);
+
+  private static Dataset<Row> testObservationNullStatusDataset;
+
+  private static Observation testObservationDecodedNullStatus;
+
   private static final Condition testCondition = TestData.newCondition();
 
   private static Dataset<Row> testConditionDataset;
@@ -127,6 +134,15 @@ public class SparkRowConverterTest {
 
     testObservationDecoded =
         (Observation) observationConverter.rowToResource(testObservationDataset.head());
+
+    Row testObservationNullStatusRow = observationConverter
+        .resourceToRow(testObservationNullStatus);
+
+    testObservationNullStatusDataset = spark.createDataFrame(
+        Collections.singletonList(testObservationNullStatusRow), observationConverter.getSchema());
+
+    testObservationDecodedNullStatus = (Observation) observationConverter
+        .rowToResource(testObservationNullStatusDataset.head());
 
     SparkRowConverter conditionConverter = SparkRowConverter.forResource(fhirContext,
         TestData.US_CORE_CONDITION);
@@ -208,6 +224,14 @@ public class SparkRowConverterTest {
 
     Assert.assertEquals(testObservation.getStatus(),
         testObservationDecoded.getStatus());
+  }
+
+  @Test
+  public void testBoundCodeNull() {
+
+    Assert.assertNull(testObservationNullStatusDataset.select("status").head().get(0));
+
+    Assert.assertNull(testObservationDecodedNullStatus.getStatusElement().getValue());
   }
 
   @Test


### PR DESCRIPTION
Closes #80 

Adds an `EnumConverter` that can handle null status code conversion.

Also loosens the Converter APIs so that outside implementations can override some functions.
