### PR TITLE
BroadcastableValueSets threading issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,6 +4,8 @@ Cerner Corporation
 
 - Ryan Brush [@rbrush]
 - Aleksander Eskilson [@bdrillard]
+- Paul Hartwell [@paulhartwell]
 
 [@rbrush]: https://github.com/rbrush
 [@bdrillard]: https://github.com/bdrillard
+[@paulhartwell]: https://github.com/PaulHartwell

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSets.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSets.java
@@ -27,16 +27,6 @@ import org.apache.spark.sql.SparkSession;
 public class BroadcastableValueSets implements Serializable {
 
   /**
-   * Spark encoder for value set references.
-   */
-  private static Encoder<Reference> REFERENCE_ENCODER = Encoders.bean(Reference.class);
-
-  /**
-   * Spark encoder for hierarchical ancestor values.
-   */
-  private static Encoder<AncestorValue> ANCESTOR_VALUE_ENCODER = Encoders.bean(AncestorValue.class);
-
-  /**
    * A map from value set reference to code system to a set of values that are contained in that
    * code system.
    */
@@ -276,7 +266,7 @@ public class BroadcastableValueSets implements Serializable {
         addReferenceVersions(valueSets);
 
         Dataset<Reference> referencesToLoad = spark.createDataset(this.references,
-            REFERENCE_ENCODER)
+            Encoders.bean(Reference.class))
             .as("toload");
 
         List<Row> codeReferences = valueSets.getValues()
@@ -304,7 +294,7 @@ public class BroadcastableValueSets implements Serializable {
         addAncestorVersions(hierarchies);
 
         Dataset<AncestorValue> ancestorsToLoad = spark.createDataset(this.ancestorValues,
-            ANCESTOR_VALUE_ENCODER)
+            Encoders.bean(AncestorValue.class))
             .as("toload");
 
         List<Row> descendants = hierarchies.getAncestors()

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSetsTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSetsTest.java
@@ -9,8 +9,15 @@ import com.cerner.bunsen.spark.codes.systems.Snomed;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.spark.sql.SparkSession;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -223,5 +230,84 @@ public class BroadcastableValueSetsTest {
     Assert.assertTrue(priorityValues.containsKey("http://hl7.org/fhir/v3/ActPriority"));
     Assert.assertTrue(ImmutableSet.of("EM")
         .containsAll(priorityValues.get("http://hl7.org/fhir/v3/ActPriority")));
+  }
+
+  @Test
+  public void testThreadSafety() {
+    List<Future> futures = new ArrayList<>();
+    final ExecutorService pool = Executors.newFixedThreadPool(5);
+
+    for (int i = 0; i < 5; i++) {
+      Future future = pool.submit(new BroadcastValueSetsThread(spark, i));
+      futures.add(future);
+    }
+
+    pool.shutdown();
+
+    boolean finished = false;
+
+    try {
+      finished = pool.awaitTermination(1, TimeUnit.MINUTES);
+    } catch (InterruptedException exception) {
+      throw new RuntimeException(exception);
+    }
+
+    if (!finished) {
+      throw new RuntimeException("Timeout occurred while awaiting completion.");
+    }
+
+    futures.stream()
+        .forEach(future -> {
+          try {
+            future.get();
+          } catch (Exception exception) {
+            throw new RuntimeException(exception);
+          }
+        });
+  }
+
+  protected class BroadcastValueSetsThread extends Thread {
+    private final SparkSession session;
+    private final int threadNum;
+
+    protected BroadcastValueSetsThread(final SparkSession session, final int threadNum) {
+      this.session = session.cloneSession();
+      this.threadNum = threadNum;
+    }
+
+    @Override
+    public void run() {
+      String bp = "bp" + threadNum;
+      String leukocytes = "leukocytes" + threadNum;
+      String priorities = "priorities" + threadNum;
+
+      BroadcastableValueSets valueSets = BroadcastableValueSets.newBuilder()
+          .addCode(bp,
+              Loinc.LOINC_CODE_SYSTEM_URI,
+              "8462-4")
+          .addDescendantsOf(leukocytes,
+              Loinc.LOINC_CODE_SYSTEM_URI,
+              "LP14419-3",
+              Loinc.LOINC_HIERARCHY_URI)
+          .addReference(priorities,
+              "http://hl7.org/fhir/ValueSet/v3-ActPriority")
+          .build(session, mockValueSets, Hierarchies.getDefault(session));
+
+      Assert.assertNotNull(valueSets);
+
+      Assert.assertTrue(ImmutableSet.of(bp, leukocytes, priorities, "types")
+          .containsAll(valueSets.getReferenceNames()));
+
+      Map<String,Set<String>> leukocyteValues = valueSets.getValues(leukocytes);
+      Map<String,Set<String>> priorityValues = valueSets.getValues(priorities);
+
+      Assert.assertTrue(leukocyteValues.containsKey("http://loinc.org"));
+      Assert.assertTrue(ImmutableSet.of("LP14419-3", "5821-4")
+          .containsAll(leukocyteValues.get("http://loinc.org")));
+
+      Assert.assertTrue(priorityValues.containsKey("http://hl7.org/fhir/v3/ActPriority"));
+      Assert.assertTrue(ImmutableSet.of("EM")
+          .containsAll(priorityValues.get("http://hl7.org/fhir/v3/ActPriority")));
+    }
   }
 }

--- a/bunsen-spark/src/test/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSetsTest.java
+++ b/bunsen-spark/src/test/java/com/cerner/bunsen/spark/codes/broadcast/BroadcastableValueSetsTest.java
@@ -232,6 +232,9 @@ public class BroadcastableValueSetsTest {
         .containsAll(priorityValues.get("http://hl7.org/fhir/v3/ActPriority")));
   }
 
+  /**
+   * Added to address https://github.com/cerner/bunsen/issues/85
+   */
   @Test
   public void testThreadSafety() {
     List<Future> futures = new ArrayList<>();

--- a/bunsen-spark/src/test/resources/log4j.properties
+++ b/bunsen-spark/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Logging configuration for running unit tests, since the default logging can be quite verbose.
+# Developers can temporarily edit the log settings below to debug tests as necessary.
+log4j.rootLogger=WARN, standard
+# Set to DEBUG to log code generated for serialization.
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection=WARN, standard
+# Set to DEBUG to log code generated for deserialization
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator=WARN, standard
+log4j.appender.standard=org.apache.log4j.ConsoleAppender
+log4j.appender.standard.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
### Summary
Issues were being seen when multiple threads were each building there own BroadcastableValueSets with unique Spark sessions.

BroadcastableValueSets had static Spark encoders which are not guaranteed to be thread safe. The encoders are now instantiated inline to prevent issues.

### Additional Details
N/A

### Issue Link
https://github.com/cerner/bunsen/issues/85