### PR TITLE
Fix for issue-93, forcing build system distribution to "trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - openjdk8
 cache:


### PR DESCRIPTION
### Summary
Temporary fix for [issue-93](https://github.com/cerner/bunsen/issues/93).
Forces build system distribution to "trusty" to pull **openjdk8** to workaround non-passive changes in Java 11 for Spark 2.4.4. 

@karthisuku @ysmwei 