### PR TITLE
issue-96: synchronize SparkRowConverter.forResource fixes intermittent NPE

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,9 +7,11 @@ Cerner Corporation
 - Paul Hartwell [@paulhartwell]
 - Amaresh Vakul [@amarvakul]
 - Yushan Wei [@ysmwei]
+- Nate Langlois [@ntlanglois]
 
 [@rbrush]: https://github.com/rbrush
 [@bdrillard]: https://github.com/bdrillard
 [@paulhartwell]: https://github.com/PaulHartwell
 [@amarvakul]: https://github.com/amarvakul
 [@ysmwei]: https://github.com/ysmwei
+[@ntlanglois]: https://github.com/ntlanglois

--- a/bunsen-spark/src/main/java/com/cerner/bunsen/spark/SparkRowConverter.java
+++ b/bunsen-spark/src/main/java/com/cerner/bunsen/spark/SparkRowConverter.java
@@ -68,7 +68,7 @@ public class SparkRowConverter {
    * @param containedResourceTypeUrls the list of URLs of contained resource types
    * @return an Avro converter instance.
    */
-  public static SparkRowConverter forResource(FhirContext context,
+  public static synchronized SparkRowConverter forResource(FhirContext context,
       String resourceTypeUrl,
       List<String> containedResourceTypeUrls) {
 


### PR DESCRIPTION
### Summary
SparkRowConverter.forResource was not thread-safe causing intermittent NullPointerException in Spark cluster mode.  See #96 

This pull makes it thread-safe by adding synchronized keyword.  The issue has not occurred ever since consuming these changes, even when using the consistent AWS EMR recreation steps described on the issue.

### Additional Details
I tried many times to write a unit test to recreate this issue, but could not, and it seems to be due to Spark local mode not introducing the same deserialization and multi-threading combination needed to recreate that Spark cluster mode introduces.  Using the same consistent AWS EMR recreation steps described on the issue is what I used for the following manual tests:

1. Without changes: fails in 46 seconds
1. Without changes: fails in 48 seconds
1. With changes: succeeds
1. With changes: succeeds
