### PR TITLE
Change declarations of null in DefinitionToAvroVisitor.java

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Cerner Corporation
 - Amaresh Vakul [@amarvakul]
 - Yushan Wei [@ysmwei]
 - Nate Langlois [@ntlanglois]
+- Sriram Iyer [@ramiyer1998]
 
 [@rbrush]: https://github.com/rbrush
 [@bdrillard]: https://github.com/bdrillard
@@ -15,3 +16,4 @@ Cerner Corporation
 [@amarvakul]: https://github.com/amarvakul
 [@ysmwei]: https://github.com/ysmwei
 [@ntlanglois]: https://github.com/ntlanglois
+[@ramiyer1998]: https://github.com/ramiyer1998

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -567,7 +567,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           .map(entry -> new Field(entry.fieldName(),
               nullable(entry.result().getDataType()),
               "Reference field",
-              (Object) null))
+              JsonProperties.NULL_VALUE))
           .collect(Collectors.toList());
 
       Schema schema = Schema.createRecord(recordName,
@@ -617,7 +617,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
               new Field(entry.fieldName(),
                   nullable(entry.result().getDataType()),
                   "Doc here",
-                  (Object) null))
+                  JsonProperties.NULL_VALUE))
           .collect(Collectors.toList());
 
       Schema schema = Schema.createRecord(recordName,
@@ -665,7 +665,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           return new Field(fieldName,
               nullable(entry.getValue().getDataType()),
               "Choice field",
-              (Object) null);
+              JsonProperties.NULL_VALUE);
 
         })
         .collect(Collectors.toList());


### PR DESCRIPTION
### Summary
In some generated avro schemas there is no default type for certain fields. The reason for this is because some field declarations in `DefinitionToAvroVisitor.java` defined null default types by using `(Object) null` rather than `JsonProperties.NULL_VALUE`, which is the preferred way to write a null object to JSON. This leads to the default field being excluded entirely from some schemas, which prevents users from using Builders for those generated objects without having to specify null for certain fields.

### Additional Details
If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process.

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Bunsen.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
