### PR TITLE
Security fix, uplift HAPI FHIR version to 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <spark.version>2.4.4</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
-    <hapi.fhir.version>3.3.0</hapi.fhir.version>
+    <hapi.fhir.version>3.8.0</hapi.fhir.version>
     <avro.version>1.8.2</avro.version>
     <junit.version>4.11</junit.version>
     <scm.url>http://github.com/cerner/bunsen/tree/master/</scm.url>


### PR DESCRIPTION
### Summary
Security fix, uplift HAPI FHIR version to 3.8.0

@ysmwei @sc036868 @karthisuku