### PR TITLE
Change null declarations in DefinitionToAvroVisitor.java

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Cerner Corporation
 - Amaresh Vakul [@amarvakul]
 - Yushan Wei [@ysmwei]
 - Nate Langlois [@ntlanglois]
+- Sriram Iyer [@ramiyer1998]
 
 [@rbrush]: https://github.com/rbrush
 [@bdrillard]: https://github.com/bdrillard
@@ -15,3 +16,4 @@ Cerner Corporation
 [@amarvakul]: https://github.com/amarvakul
 [@ysmwei]: https://github.com/ysmwei
 [@ntlanglois]: https://github.com/ntlanglois
+[@ramiyer1998]: https://github.com/ramiyer1998

--- a/bunsen-avro-records-stu3/pom.xml
+++ b/bunsen-avro-records-stu3/pom.xml
@@ -135,7 +135,10 @@
             <argument>${project.build.directory}/fhir_resources.avpr</argument>
 
             <!-- FHIR resources to generate. All data elements contained in these
-                 resources will be generated as well. -->
+                 resources will be generated as well. -->           
+            
+            <!-- NOTE: Contained classes should be in the same argument as their
+                 parent class, deliminated by semicolons (i.e. resource;contained) -->
 
             <!-- Base Resources -->
             <argument>http://hl7.org/fhir/StructureDefinition/Patient</argument>
@@ -153,6 +156,7 @@
             <argument>http://hl7.org/fhir/StructureDefinition/ProcedureRequest</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Observation</argument>
             <argument>http://hl7.org/fhir/StructureDefinition/Procedure</argument>
+            <argument>http://hl7.org/fhir/StructureDefinition/MedicationRequest;http://hl7.org/fhir/StructureDefinition/Medication</argument>
 
             <!-- US Core Resources -->
             <argument>http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient</argument>

--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -353,14 +353,14 @@ public class SpecificRecordsTest {
   }
 
   @Test
-  public void testNullDefaultValuesProperlyEncodedForContainedTypes() {
+  public void testNullDefaultValuesForContainedTypes() {
     MedicationRequestContained medicationRequest =
         MedicationRequestContained.newBuilder().build();
     Assert.assertNull(medicationRequest.getMedication());
   }
 
   @Test
-  public void testNullDefaultValuesProperlyEncodedForCompositeTypes() {
+  public void testNullDefaultValuesForCompositeTypes() {
     ConditionEvidence conditionEvidence =
         ConditionEvidence.newBuilder().build();
     Assert.assertNull(conditionEvidence.getId());
@@ -370,7 +370,7 @@ public class SpecificRecordsTest {
 
 
   @Test
-  public void testNullDefaultValuesProperlyEncodedForParentExtensionTypes() {
+  public void testNullDefaultValuesForParentExtensionTypes() {
     UsCoreRace usCoreRace = UsCoreRace.newBuilder().build();
     Assert.assertNull(usCoreRace.getOmbCategory());
     Assert.assertNull(usCoreRace.getDetailed());
@@ -378,7 +378,7 @@ public class SpecificRecordsTest {
   }
 
   @Test
-  public void testNullDefaultValuesProperlyEncodedForChoiceTypes() {
+  public void testNullDefaultValuesForChoiceTypes() {
     ChoicePeriodDate cpd = ChoicePeriodDate.newBuilder().build();
     Assert.assertNull(cpd.getDate());
 
@@ -389,7 +389,7 @@ public class SpecificRecordsTest {
   }
 
   @Test
-  public void testNullDefaultValuesProperlyEncodedForReferenceTypes() {
+  public void testNullDefaultValuesForReferenceTypes() {
     OrganizationPractitionerReference opr =
         OrganizationPractitionerReference.newBuilder().build();
     Assert.assertNull(opr.getOrganizationId());

--- a/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
+++ b/bunsen-avro-records-stu3/src/test/java/com/cerner/bunsen/avro/SpecificRecordsTest.java
@@ -1,15 +1,20 @@
 package com.cerner.bunsen.avro;
 
 import com.cerner.bunsen.FhirContexts;
+import com.cerner.bunsen.stu3.TestData;
+import com.cerner.bunsen.stu3.avro.ChoiceAddressCodeableConceptLocationReference;
+import com.cerner.bunsen.stu3.avro.ChoicePeriodDate;
+import com.cerner.bunsen.stu3.avro.MedicationRequestContained;
 import com.cerner.bunsen.stu3.avro.Observation;
 import com.cerner.bunsen.stu3.avro.OrganizationPractitionerReference;
 import com.cerner.bunsen.stu3.avro.PatientReference;
+import com.cerner.bunsen.stu3.avro.us.core.ConditionEvidence;
+import com.cerner.bunsen.stu3.avro.us.core.Patient;
 import com.cerner.bunsen.stu3.avro.us.core.UsCoreEthnicity;
-import com.cerner.bunsen.stu3.TestData;
+import com.cerner.bunsen.stu3.avro.us.core.UsCoreRace;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
-
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.IntegerType;
@@ -17,8 +22,6 @@ import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Quantity;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.cerner.bunsen.stu3.avro.us.core.Patient;
 
 /**
  * Unit test for conversion of specific records to and from HAPI resources.
@@ -349,4 +352,50 @@ public class SpecificRecordsTest {
     Assert.assertEquals(testProvenanceId, decodedProvenanceId);
   }
 
+  @Test
+  public void testNullDefaultValuesProperlyEncodedForContainedTypes() {
+    MedicationRequestContained medicationRequest =
+        MedicationRequestContained.newBuilder().build();
+    Assert.assertNull(medicationRequest.getMedication());
+  }
+
+  @Test
+  public void testNullDefaultValuesProperlyEncodedForCompositeTypes() {
+    ConditionEvidence conditionEvidence =
+        ConditionEvidence.newBuilder().build();
+    Assert.assertNull(conditionEvidence.getId());
+    Assert.assertNull(conditionEvidence.getCode());
+    Assert.assertNull(conditionEvidence.getDetail());
+  }
+
+
+  @Test
+  public void testNullDefaultValuesProperlyEncodedForParentExtensionTypes() {
+    UsCoreRace usCoreRace = UsCoreRace.newBuilder().build();
+    Assert.assertNull(usCoreRace.getOmbCategory());
+    Assert.assertNull(usCoreRace.getDetailed());
+    Assert.assertNull(usCoreRace.getText());
+  }
+
+  @Test
+  public void testNullDefaultValuesProperlyEncodedForChoiceTypes() {
+    ChoicePeriodDate cpd = ChoicePeriodDate.newBuilder().build();
+    Assert.assertNull(cpd.getDate());
+
+    ChoiceAddressCodeableConceptLocationReference testLocation =
+        ChoiceAddressCodeableConceptLocationReference.newBuilder().build();
+    Assert.assertNull(testLocation.getAddress());
+    Assert.assertNull(testLocation.getReference());
+  }
+
+  @Test
+  public void testNullDefaultValuesProperlyEncodedForReferenceTypes() {
+    OrganizationPractitionerReference opr =
+        OrganizationPractitionerReference.newBuilder().build();
+    Assert.assertNull(opr.getOrganizationId());
+    Assert.assertNull(opr.getId());
+    Assert.assertNull(opr.getReference());
+    Assert.assertNull(opr.getIdentifier());
+    Assert.assertNull(opr.getDisplay());
+  }
 }

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/converters/DefinitionToAvroVisitor.java
@@ -567,7 +567,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           .map(entry -> new Field(entry.fieldName(),
               nullable(entry.result().getDataType()),
               "Reference field",
-              (Object) null))
+              JsonProperties.NULL_VALUE))
           .collect(Collectors.toList());
 
       Schema schema = Schema.createRecord(recordName,
@@ -617,7 +617,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
               new Field(entry.fieldName(),
                   nullable(entry.result().getDataType()),
                   "Doc here",
-                  (Object) null))
+                  JsonProperties.NULL_VALUE))
           .collect(Collectors.toList());
 
       Schema schema = Schema.createRecord(recordName,
@@ -665,7 +665,7 @@ public class DefinitionToAvroVisitor implements DefinitionVisitor<HapiConverter<
           return new Field(fieldName,
               nullable(entry.getValue().getDataType()),
               "Choice field",
-              (Object) null);
+              JsonProperties.NULL_VALUE);
 
         })
         .collect(Collectors.toList());

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -2,6 +2,7 @@ package com.cerner.bunsen.avro.tools;
 
 import com.cerner.bunsen.FhirContexts;
 import com.cerner.bunsen.avro.AvroConverter;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,7 +54,7 @@ public class GenerateSchemas {
 
     Map<String, List<String>> resourceTypeUrls = Arrays.stream(args)
         .skip(1)
-        .collect(Collectors.toMap(Function.identity(), item -> Collections.emptyList()));
+        .collect(Collectors.toMap(item -> item.split(";")[0], item -> generateContainedUrls(item)));
 
     List<Schema> schemas = AvroConverter.generateSchemas(FhirContexts.forStu3(), resourceTypeUrls);
 
@@ -76,5 +77,20 @@ public class GenerateSchemas {
     }
 
     return 0;
+  }
+
+  /**
+   * Helper function to extract contained resources from resource string.
+   * 
+   * @param key the string containing resource url(s)
+   * @return the list of contained urls
+   */
+  private static List<String> generateContainedUrls(String key) {
+    if (!key.contains(";")) {
+      return Collections.emptyList();
+    }
+    String[] splitKey = key.split(";");
+    String[] valList = Arrays.copyOfRange(splitKey, 1, splitKey.length);
+    return Arrays.asList(valList);
   }
 }

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -20,7 +20,7 @@ import org.apache.avro.Schema;
  */
 public class GenerateSchemas {
 
-  private static final String DELIMITER = ";";
+  public static final String DELIMITER = ";";
 
   /**
    * Main entrypoint for schema generation tool.

--- a/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
+++ b/bunsen-avro/src/main/java/com/cerner/bunsen/avro/tools/GenerateSchemas.java
@@ -20,6 +20,8 @@ import org.apache.avro.Schema;
  */
 public class GenerateSchemas {
 
+  private static final String DELIMITER = ";";
+
   /**
    * Main entrypoint for schema generation tool.
    *
@@ -54,7 +56,8 @@ public class GenerateSchemas {
 
     Map<String, List<String>> resourceTypeUrls = Arrays.stream(args)
         .skip(1)
-        .collect(Collectors.toMap(item -> item.split(";")[0], item -> generateContainedUrls(item)));
+        .collect(Collectors.toMap(item -> item.split(DELIMITER)[0],
+            item -> generateContainedUrls(item)));
 
     List<Schema> schemas = AvroConverter.generateSchemas(FhirContexts.forStu3(), resourceTypeUrls);
 
@@ -85,11 +88,11 @@ public class GenerateSchemas {
    * @param key the string containing resource url(s)
    * @return the list of contained urls
    */
-  private static List<String> generateContainedUrls(String key) {
-    if (!key.contains(";")) {
+  public static List<String> generateContainedUrls(String key) {
+    if (!key.contains(DELIMITER)) {
       return Collections.emptyList();
     }
-    String[] splitKey = key.split(";");
+    String[] splitKey = key.split(DELIMITER);
     String[] valList = Arrays.copyOfRange(splitKey, 1, splitKey.length);
     return Arrays.asList(valList);
   }

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
@@ -4,10 +4,16 @@ import com.cerner.bunsen.stu3.TestData;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class GenerateSchemasTest {
+
+  private static final String BASE_TEST_URL = "http://test.org/test_resource";
 
   @Test
   public void testWriteSchema() throws IOException {
@@ -28,5 +34,46 @@ public class GenerateSchemasTest {
     Assert.assertEquals(0, result);
 
     Assert.assertTrue(outputFile.toFile().exists());
+  }
+
+  @Test
+  public void testGenerateContainedUrlsWithEmptyStringReturnsEmptyList() {
+    Assert.assertEquals(Collections.emptyList(), GenerateSchemas.generateContainedUrls(""));
+  }
+
+  @Test
+  public void testGenerateContainedUrlsWithStringWithoutSemicolonReturnsEmptyList() {
+    String testResource = BASE_TEST_URL;
+    Assert.assertEquals(Collections.emptyList(), 
+        GenerateSchemas.generateContainedUrls(testResource));
+  }
+
+  @Test
+  public void testGenerateContainedUrlsWithStringWithOneContainedResource() {
+    String testResourceWithContained = 
+        BASE_TEST_URL + ";http://test.org/test_contained";
+    List<String> testContainedList = 
+        GenerateSchemas.generateContainedUrls(testResourceWithContained);
+
+    Assert.assertEquals(1, testContainedList.size());
+    Assert.assertEquals("http://test.org/test_contained", testContainedList.get(0));
+  }
+
+  @Test
+  public void testGenerateContainedUrlWithStringWithMultipleContainedResources() {
+    StringJoiner joiner = new StringJoiner(";");
+    joiner.add(BASE_TEST_URL);
+    String[] originalList = new String[10];
+
+    for (int x = 0; x < 10; x++) {
+      String curr = "http://test.org/contained_" + x;
+      originalList[x] = curr;
+      joiner.add(curr);
+    }
+
+    List<String> testContainedList =
+        GenerateSchemas.generateContainedUrls(joiner.toString());
+
+    Assert.assertEquals(Arrays.asList(originalList), testContainedList);
   }
 }

--- a/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
+++ b/bunsen-avro/src/test/java/com/cerner/bunsen/avro/tools/GenerateSchemasTest.java
@@ -51,7 +51,7 @@ public class GenerateSchemasTest {
   @Test
   public void testGenerateContainedUrlsWithStringWithOneContainedResource() {
     String testResourceWithContained = 
-        BASE_TEST_URL + ";http://test.org/test_contained";
+        BASE_TEST_URL + GenerateSchemas.DELIMITER + "http://test.org/test_contained";
     List<String> testContainedList = 
         GenerateSchemas.generateContainedUrls(testResourceWithContained);
 
@@ -61,7 +61,7 @@ public class GenerateSchemasTest {
 
   @Test
   public void testGenerateContainedUrlWithStringWithMultipleContainedResources() {
-    StringJoiner joiner = new StringJoiner(";");
+    StringJoiner joiner = new StringJoiner(GenerateSchemas.DELIMITER);
     joiner.add(BASE_TEST_URL);
     String[] originalList = new String[10];
 


### PR DESCRIPTION
### Summary
In some generated avro schemas there is no default type for certain fields. The reason for this is because some field declarations in `DefinitionToAvroVisitor.java` defined null default types by using `(Object) null` rather than `JsonProperties.NULL_VALUE`, which is the preferred way to write a null object to JSON. This leads to the default field being excluded entirely from some schemas, which prevents users from using Builders for those generated objects without having to specify null for certain fields.

For completeness' sake:
<img width="516" alt="Screen Shot 2020-10-22 at 9 54 02 AM" src="https://user-images.githubusercontent.com/17326751/96881718-8c5e6a80-144c-11eb-8b21-3399fbc0d1f2.png">


### Additional Details
If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process.

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Bunsen.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
