### PR TITLE
Customized id conversion to use getIdPart instead of getValue.

### DIFF
--- a/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
+++ b/bunsen-core/src/main/java/com/cerner/bunsen/definitions/PrimitiveConverter.java
@@ -3,6 +3,7 @@ package com.cerner.bunsen.definitions;
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
 public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
@@ -54,13 +55,19 @@ public abstract class PrimitiveConverter<T> extends HapiConverter<T> {
     primitive.setValue(input);
   }
 
+  protected Object fromHapi(IIdType id) {
+    return id.getIdPart();
+  }
+
   protected Object fromHapi(IPrimitiveType primitive) {
     return primitive.getValue();
   }
 
   @Override
   public Object fromHapi(Object input) {
-
+    if (input instanceof IIdType) {
+      return fromHapi((IIdType) input);
+    }
     return fromHapi((IPrimitiveType) input);
   }
 

--- a/bunsen-spark-stu3/src/test/java/com/cerner/bunsen/stu3/BundlesTest.java
+++ b/bunsen-spark-stu3/src/test/java/com/cerner/bunsen/stu3/BundlesTest.java
@@ -133,9 +133,9 @@ public class BundlesTest {
     Assert.assertEquals(3, patientIds.size());
 
     List<String> expectedIds = ImmutableList.of(
-        "Patient/6666001",
-        "Patient/1032702",
-        "Patient/9995679");
+        "6666001",
+        "1032702",
+        "9995679");
 
     Assert.assertTrue(patientIds.containsAll(expectedIds));
   }
@@ -158,11 +158,11 @@ public class BundlesTest {
     Assert.assertEquals(5, conditionIds.size());
 
     List<String> expectedIds = ImmutableList.of(
-        "Condition/119",
-        "Condition/120",
-        "Condition/121",
-        "Condition/122",
-        "Condition/123");
+        "119",
+        "120",
+        "121",
+        "122",
+        "123");
 
     Assert.assertTrue(conditionIds.containsAll(expectedIds));
   }


### PR DESCRIPTION
### Summary
This is a proposed solution for Issue #106, i.e., change id conversion to only return the logical id (and not the full URL).

### Additional Details
This is just one proposal (as I am not that familiar with Bunsen's code) but it seems to resolve our problem as shown in the updated test in [this commit](https://github.com/bashir2/openmrs-fhir-analytics/commit/4098e3528881ddfce0155ad76ab664be5403fe33).

TODO (in case we want to go ahead with this solution):
Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Bunsen.

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
